### PR TITLE
added ARGs for deployment purposes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ WORKDIR /var/app/scholars-angular
 # install dependencies
 RUN yarn install
 
+#Set Args defaults for build
+ARG HOST=localhost
+ARG PORT=4200
+
 # build app with server side rendering in production 
 RUN yarn build:ssr:prod
 


### PR DESCRIPTION
I used the following build command:
docker build -t /scholars-ui:v1.4 .

and the run command:
docker run /scholars-ui:v1.4

This fixes an issue with the dockerfile when we were deploying to our infrastructure. The build was not allowing for HOST to change from localhost to our environment.