### PR TITLE
Only expose co-author network if individual has publications

### DIFF
--- a/src/app/+visualization/co-investigator-network/co-investigator-network.component.html
+++ b/src/app/+visualization/co-investigator-network/co-investigator-network.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="individual | async; let individual" [@fadeIn]>
   <div class="float-right">
-    <div class="text-nowrap">
+    <div class="text-nowrap" *ngIf="individual.publications !== undefined">
       <img src="assets/images/co_author_icon.png" height="25" width="25" alt="{{ 'VISUALIZATION.NETWORK.COAUTHOR.ICON_ALT' | translate }}">
       <span class="ml-2">
         <a [routerLink]="['/visualization', individual.id, 'Co-author Network']">{{ 'VISUALIZATION.NETWORK.COAUTHOR.LABEL' | translate }}</a>


### PR DESCRIPTION
This PR resolves #324. The link from co-investigator to co-author should not be exposed if the individual has no publications.