### PR TITLE
[Issue 333, Issue 334, Issue 345] Data and analytic view navigation update - merge conflicts resolved

### DIFF
--- a/src/app/+data-and-analytics/data-and-analytics.component.html
+++ b/src/app/+data-and-analytics/data-and-analytics.component.html
@@ -35,12 +35,12 @@
                     <div *ngSwitchCase="'PROFILE_SUMMARIES_EXPORT'">
                       <span>{{ view.type }}</span>
                     </div>
-                    <div *ngSwitchDefault>{{ view.layout }} Unknown</div>
+                    <div *ngSwitchDefault>{{ 'DATA_AND_ANALYTICS.UNKNOWN' | translate: { value: view.layout } }}</div>
                   </div>
                 </div>
-                <div *ngSwitchCase="'GRID'">{{ view.layout }} Not Supported</div>
-                <div *ngSwitchCase="'LIST'">{{ view.layout }} Not Supported</div>
-                <div *ngSwitchDefault>{{ view.layout }} Unknown</div>
+                <div *ngSwitchCase="'GRID'">{{ 'DATA_AND_ANALYTICS.NOT_SUPPORTED' | translate: { value: view.layout } }}</div>
+                <div *ngSwitchCase="'LIST'">{{ 'DATA_AND_ANALYTICS.NOT_SUPPORTED' | translate: { value: view.layout } }}</div>
+                <div *ngSwitchDefault>{{ 'DATA_AND_ANALYTICS.UNKNOWN' | translate: { value: view.layout } }}</div>
               </div>
             </a>
           </div>
@@ -53,7 +53,7 @@
             <div class="card-header">
               <div class="d-flex justify-content-between align-items-center" *ngIf="themeOrganizationId | async; let themeOrganizationId">
                 <div>{{ view.name }}</div>
-                <a class="btn btn-link text-primary" (click)="onSelectOrganization(themeOrganizationId, params)">Reset Filter</a>
+                <a class="btn btn-link text-primary" (click)="onSelectOrganization(themeOrganizationId, params)">{{ 'DATA_AND_ANALYTICS.RESET' | translate }}</a>
               </div>
             </div>
             <div class="card-body" [ngSwitch]="view.layout">
@@ -145,12 +145,12 @@
                       (labelEvent)="onLabelEvent($event)">
                     </scholars-profile-summaries-export>
                   </div>
-                  <div *ngSwitchDefault>{{ view.type }} Unknown</div>
+                  <div *ngSwitchDefault>{{ 'DATA_AND_ANALYTICS.UNKNOWN' | translate: { value: view.type } }}</div>
                 </div>
               </div>
-              <div *ngSwitchCase="'GRID'">{{ view.layout }} Not Supported</div>
-              <div *ngSwitchCase="'LIST'">{{ view.layout }} Not Supported</div>
-              <div *ngSwitchDefault>{{ view.layout }} Unknown</div>
+              <div *ngSwitchCase="'GRID'">{{ 'DATA_AND_ANALYTICS.NOT_SUPPORTED' | translate: { value: view.layout } }}</div>
+              <div *ngSwitchCase="'LIST'">{{ 'DATA_AND_ANALYTICS.NOT_SUPPORTED' | translate: { value: view.layout } }}</div>
+              <div *ngSwitchDefault>{{ 'DATA_AND_ANALYTICS.UNKNOWN' | translate: { value: view.layout } }}</div>
             </div>
           </div>
         </div>

--- a/src/app/+data-and-analytics/data-and-analytics.component.html
+++ b/src/app/+data-and-analytics/data-and-analytics.component.html
@@ -1,29 +1,19 @@
 <scholars-sidebar *ngIf="queryParams | async; let params">
-  <!-- view navigation -->
-  <nav aria-label="breadcrumb" *ngIf="dataAndAnalyticsView | async; let view">
-    <ol class="breadcrumb" *ngIf="displayView | async; let displayView">
-      <li class="breadcrumb-item active" aria-current="page">
-        <a [routerLink]="['/data-and-analytics']">{{ 'DATA_AND_ANALYTICS.LABEL' | translate }}</a>
-      </li>
-      <li class="breadcrumb-item active" aria-current="page" >
-        <a [routerLink]="['/data-and-analytics', view.name]" [queryParams]="getQueryParams(params, view, displayView)">{{ view.name }} </a>
-      </li>
-    </ol>
-  </nav>
+  <div *ngIf="selectedOrganization | async; let organization">
 
-  <!-- organization navigation -->
-  <nav aria-label="breadcrumb">
-    <ol class="breadcrumb" *ngIf="organizations | async; let organizations">
-      <ng-template ngFor let-organization [ngForOf]="organizations" let-i="organization"  let-index="index"  [ngForTrackBy]="trackByIndex">
+     <!-- view navigation -->
+    <nav aria-label="breadcrumb" *ngIf="dataAndAnalyticsView | async; let view">
+      <ol class="breadcrumb" *ngIf="displayView | async; let displayView">
         <li class="breadcrumb-item active" aria-current="page">
-          <a (click)="onNavigateOrganization(params, organizations, index)">{{ organization.name }}</a>
+          <a [routerLink]="['/data-and-analytics']">{{ 'DATA_AND_ANALYTICS.LABEL' | translate }}</a>
         </li>
-      </ng-template>
-    </ol>
-  </nav>
+        <li class="breadcrumb-item active" aria-current="page" >
+          <a [routerLink]="['/data-and-analytics', view.name]" [queryParams]="getQueryParams(params, view, displayView, organization.id)">{{ organization.name }} </a>
+        </li>
+      </ol>
+    </nav>
 
-  <div *ngIf="displayView | async; let displayView">
-    <div *ngIf="selectedOrganization | async; let organization">
+    <div *ngIf="displayView | async; let displayView">
 
       <div class="card-columns" *ngIf="isDashboard | async" [@fadeIn]>
         <ng-template ngFor let-view [ngForOf]="dataAndAnalyticsViews | async" let-i="view" [ngForTrackBy]="trackByIndex">
@@ -61,7 +51,10 @@
         <div class="card-deck">
           <div class="card">
             <div class="card-header">
-              {{ view.name }}
+              <div class="d-flex justify-content-between align-items-center" *ngIf="themeOrganizationId | async; let themeOrganizationId">
+                <div>{{ view.name }}</div>
+                <a class="btn btn-link text-primary" (click)="onSelectOrganization(themeOrganizationId, params)">Reset Filter</a>
+              </div>
             </div>
             <div class="card-body" [ngSwitch]="view.layout">
 
@@ -74,7 +67,7 @@
               <div class="row p-1 mb-2">
                 <div class="col-12">
                   <span class="h4 font-weight-bold">{{ 'DATA_AND_ANALYTICS.ORGANIZATION' | translate }}: </span>
-                  <span class="h4">{{ organization.name }} ({{ organization.people.length }})</span>
+                  <span class="h4">{{ organization.name }} ({{ organization.people?.length }})</span>
                 </div>
               </div>
 
@@ -92,30 +85,30 @@
               </div>
 
               <div class="row p-1">
-                <div class="col-4" *ngIf="(colleges | async).length > 0">
+                <div class="col-4" *ngIf="colleges | async; let colleges">
                   <div class="form-group">
                     <label class="font-weight-bold">{{ 'DATA_AND_ANALYTICS.COLLEGE' | translate }}</label>
-                    <select class="form-control" ngModel (ngModelChange)="onSelectOrganization($event, params)">
+                    <select #collegesSelect id="collegesSelect" class="form-control" ngModel (ngModelChange)="onSelectOrganization($event, params, collegesSelect)">
                       <option value="" disabled selected>{{ 'DATA_AND_ANALYTICS.SELECT' | translate }}</option>
-                      <option *ngFor="let so of colleges | async" [ngValue]="so.id">{{ so.label }}</option>
+                      <option *ngFor="let so of colleges" [ngValue]="so.id">{{ so.name }}</option>
                     </select>
                   </div>
                 </div>
-                <div class="col-4" *ngIf="(departments | async).length > 0">
+                <div class="col-4" *ngIf="departments | async; let departments">
                   <div class="form-group">
                     <label class="font-weight-bold">{{ 'DATA_AND_ANALYTICS.DEPARTMENT' | translate }}</label>
-                    <select class="form-control" ngModel (ngModelChange)="onSelectOrganization($event, params)">
+                    <select #departmentsSelect id="departmentsSelect" class="form-control" ngModel (ngModelChange)="onSelectOrganization($event, params, departmentsSelect)">
                       <option value="" disabled selected>{{ 'DATA_AND_ANALYTICS.SELECT' | translate }}</option>
-                      <option *ngFor="let so of departments | async" [ngValue]="so.id">{{ so.label }}</option>
+                      <option *ngFor="let so of departments" [ngValue]="so.id">{{ so.name }}</option>
                     </select>
                   </div>
                 </div>
-                <div class="col-4" *ngIf="(others | async).length > 0">
+                <div class="col-4" *ngIf="others | async; let others">
                   <div class="form-group">
                     <label class="font-weight-bold">{{ 'DATA_AND_ANALYTICS.OTHERS' | translate }}</label>
-                    <select class="form-control" ngModel (ngModelChange)="onSelectOrganization($event, params)">
+                    <select #othersSelect id="othersSelect" class="form-control" ngModel (ngModelChange)="onSelectOrganization($event, params, othersSelect)">
                       <option value="" disabled selected>{{ 'DATA_AND_ANALYTICS.SELECT' | translate }}</option>
-                      <option *ngFor="let so of others | async" [ngValue]="so.id">{{ so.label }}</option>
+                      <option *ngFor="let so of others" [ngValue]="so.id">{{ so.name }}</option>
                     </select>
                   </div>
                 </div>

--- a/src/app/+data-and-analytics/data-and-analytics.component.spec.ts
+++ b/src/app/+data-and-analytics/data-and-analytics.component.spec.ts
@@ -1,13 +1,18 @@
 import { APP_BASE_HREF } from '@angular/common';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { StoreModule } from '@ngrx/store';
+import { REQUEST } from '@nguniversal/express-engine/tokens';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { testAppConfig } from '../../test.config';
+import { getRequest } from '../app.browser.module';
 import { APP_CONFIG } from '../app.config';
+import { IndividualRepo } from '../core/model/discovery/repo/individual.repo';
+import { RestService } from '../core/service/rest.service';
 import { metaReducers, reducers } from '../core/store';
 import { SharedModule } from '../shared/shared.module';
 import { DataAndAnalyticsComponent } from './data-and-analytics.component';
@@ -23,6 +28,7 @@ describe('DataAndAnalyticsComponent', () => {
       imports: [
         NoopAnimationsModule,
         SharedModule,
+        HttpClientTestingModule,
         StoreModule.forRoot(reducers(testAppConfig), {
           metaReducers,
           runtimeChecks: {
@@ -38,6 +44,10 @@ describe('DataAndAnalyticsComponent', () => {
       providers: [
         { provide: APP_CONFIG, useValue: testAppConfig },
         { provide: APP_BASE_HREF, useValue: '/' },
+        { provide: REQUEST, useFactory: getRequest },
+        { provide: APP_CONFIG, useValue: testAppConfig },
+        RestService,
+        IndividualRepo
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();

--- a/src/app/+data-and-analytics/data-and-analytics.component.ts
+++ b/src/app/+data-and-analytics/data-and-analytics.component.ts
@@ -1,14 +1,15 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { Store, select } from '@ngrx/store';
-import { BehaviorSubject, Observable, filter, map, take, tap, withLatestFrom } from 'rxjs';
+import { BehaviorSubject, Observable, combineLatest, filter, map, switchMap, take, withLatestFrom } from 'rxjs';
 
 import { Individual } from '../core/model/discovery';
-import { DataAndAnalyticsView, DisplayView, Filter } from '../core/model/view';
+import { IndividualRepo } from '../core/model/discovery/repo/individual.repo';
+import { DataAndAnalyticsView, DisplayView, Filter, OpKey } from '../core/model/view';
 import { ContainerType } from '../core/model/view/data-and-analytics-view';
 import { AppState } from '../core/store';
 import { selectRouterQueryParamFilters, selectRouterQueryParams, selectRouterState } from '../core/store/router';
-import { selectAllResources, selectDisplayViewByTypes, selectResourceById } from '../core/store/sdr';
+import { selectAllResources, selectDisplayViewByTypes, selectResourceSelected } from '../core/store/sdr';
 import { selectActiveThemeOrganizationId } from '../core/store/theme';
 import { fadeIn } from '../shared/utilities/animation.utility';
 import { getFilterField, getFilterValue, getQueryParamsForFacets, removeFilterFromQueryParams, resetFiltersInQueryParams, showClearFilters, showFilter } from '../shared/utilities/view.utility';
@@ -26,6 +27,10 @@ import * as fromSidebar from '../core/store/sidebar/sidebar.actions';
 })
 export class DataAndAnalyticsComponent implements OnInit {
 
+  @ViewChild('collegesSelect') collegesSelect: ElementRef<HTMLSelectElement>;
+  @ViewChild('departmentsSelect') departmentsSelect: ElementRef<HTMLSelectElement>;
+  @ViewChild('othersSelect') othersSelect: ElementRef<HTMLSelectElement>;
+
   public displayView: Observable<DisplayView>;
 
   public dataAndAnalyticsView: Observable<DataAndAnalyticsView>;
@@ -42,34 +47,15 @@ export class DataAndAnalyticsComponent implements OnInit {
 
   public filters: Observable<any[]>;
 
-  public organizations: Observable<Individual[]>;
-
-  public selectedOrganizationSubject: BehaviorSubject<Individual>;
+  public selectedOrganization: Observable<Individual>;
 
   public labelSubject: BehaviorSubject<string>;
 
-  public get colleges(): Observable<any[]> {
-    return this.selectedOrganization.pipe(
-      map((org: Individual) => this.filterSubOrganization(org, ['College']))
-    );
-  };
+  public colleges: Observable<Individual[]>;
 
-  public get departments(): Observable<any[]> {
-    return this.selectedOrganization.pipe(
-      map((org: Individual) => this.filterSubOrganization(org, ['AcademicDepartment']))
-    );
-  };
+  public departments: Observable<Individual[]>;
 
-  public get others(): Observable<any[]> {
-    return this.selectedOrganization.pipe(
-      map((org: Individual) => this.filterSubOrganization(org, ['!College', '!AcademicDepartment']))
-    );
-  };
-
-  public get selectedOrganization(): Observable<Individual> {
-    return this.selectedOrganizationSubject.asObservable()
-      .pipe(filter((org: Individual) => !!org));
-  }
+  public others: Observable<Individual[]>;
 
   public get label(): Observable<string> {
     return this.labelSubject.asObservable();
@@ -78,15 +64,16 @@ export class DataAndAnalyticsComponent implements OnInit {
   constructor(
     private router: Router,
     private route: ActivatedRoute,
-    private store: Store<AppState>
+    private store: Store<AppState>,
+    private individualRepo: IndividualRepo,
   ) {
-    this.selectedOrganizationSubject = new BehaviorSubject<Individual>(undefined);
     this.labelSubject = new BehaviorSubject<string>('');
   }
 
   ngOnInit(): void {
     this.store.dispatch(new fromSidebar.UnloadSidebarAction());
     this.store.dispatch(new fromLayout.CloseSidebarAction());
+
     this.store.dispatch(new fromSdr.ClearResourcesAction('individual'));
 
     this.queryParams = this.store.pipe(select(selectRouterQueryParams));
@@ -105,51 +92,45 @@ export class DataAndAnalyticsComponent implements OnInit {
       map((router: any) => !!router && router.state.url === '/data-and-analytics')
     );
 
-    this.organizations = this.store.pipe(
-      select(selectAllResources('individual')),
-      tap((organizations: Individual[]) => {
-        this.selectedOrganizationSubject.next(organizations[organizations.length - 1]);
-      })
+    this.selectedOrganization = this.store.pipe(
+      select(selectResourceSelected('individual')),
+      filter((organization: Individual) => !!organization),
     );
 
-    this.themeOrganizationId = this.store.select(selectActiveThemeOrganizationId);
+    this.colleges = this.getOrganizationsByTypes(['College']);
 
-    this.themeOrganizationId
-      .pipe(
-        filter(id => !!id),
-        take(1)
-    ).subscribe(id => {
+    this.departments = this.getOrganizationsByTypes(['AcademicDepartment']);
 
-      this.organization = this.store.pipe(
-        select(selectResourceById('individual', id)),
-        filter((organization: Individual) => !!organization)
-      );
+    this.others = this.getOrganizationsByTypes(['AdministrativeUnit', 'AffiliatedAgency', 'Association', 'BranchCampus', 'Center', 'Hospital', 'Institute', 'Laboratory', 'Library', 'Program', 'School', 'University']);
 
-      this.organization.pipe(take(1))
-        .subscribe((organization) => {
+    this.themeOrganizationId = this.store.pipe(
+      select(selectActiveThemeOrganizationId),
+      filter(id => !!id),
+      take(1)
+    );
+
+    combineLatest([this.queryParams.pipe(take(1)), this.themeOrganizationId])
+      .pipe(take(1))
+      .subscribe(([querParams, themeOrganizationId]) => {
+        const id = querParams.selectedOrganization ? querParams.selectedOrganization : themeOrganizationId;
+
+        this.store.pipe(
+          select(selectResourceSelected('individual')),
+          filter((organization: Individual) => !!organization),
+          take(1),
+        ).subscribe((organization) => {
           this.displayView = this.store.pipe(
             select(selectDisplayViewByTypes(organization.type)),
             filter((displayView: DisplayView) => !!displayView)
           );
-
           this.store.dispatch(
             new fromSdr.FindByTypesInResourceAction('displayViews', {
               types: organization.type,
             })
           );
-
-          this.queryParams.pipe(take(1)).subscribe((params: Params) => {
-            if (!!params.selectedOrganizations) {
-              const ids = params.selectedOrganizations.split(',');
-              const id = ids.shift();
-              const queue = ids.map((id: string) => new fromSdr.GetOneResourceAction('individual', { id }));
-              this.store.dispatch(new fromSdr.GetOneResourceAction('individual', { id, queue }));
-            }
-          });
         });
 
-        this.store.dispatch(new fromSdr.GetOneResourceAction('individual', { id }));
-
+        this.store.dispatch(new fromSdr.SelectResourceAction('individual', { id }));
       });
   }
 
@@ -158,13 +139,13 @@ export class DataAndAnalyticsComponent implements OnInit {
   }
 
   public getDataAndAnalyticsQueryParamsRemovingFilter(params: Params, filterToRemove: Filter): Params {
-    const queryParams: Params = Object.assign({}, params);
+    const queryParams: Params = { ...params };
     removeFilterFromQueryParams(queryParams, filterToRemove);
     return queryParams;
   }
 
   public getDataAndAnalyticsQueryParamsClearingFilters(params: Params, view: DataAndAnalyticsView): Params {
-    const queryParams: Params = Object.assign({}, params);
+    const queryParams: Params = { ...params };
     resetFiltersInQueryParams(queryParams, view);
     return queryParams;
   }
@@ -189,43 +170,30 @@ export class DataAndAnalyticsComponent implements OnInit {
     return index;
   }
 
-  public onNavigateOrganization(params: Params, organizations: Individual[], index: number): void {
-    const selectedOrganizations: string[] = !!params.selectedOrganizations
-      ? params.selectedOrganizations.split(',')
-      : [];
+  public onSelectOrganization(id: any, params: Params, changedSelect?: any): void {
 
-    let org;
-    while (!!(org = organizations[++index])) {
-      const id = org.id;
-      this.store.dispatch(new fromSdr.ClearResourceByIdAction('individual', { id }));
-      let i;
-      if ((i = selectedOrganizations.indexOf(id)) >= 0) {
-        selectedOrganizations.splice(i, 1);
-      }
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { ...params, selectedOrganization: id },
+      queryParamsHandling: 'merge'
+    });
+
+    if (this.collegesSelect && this.collegesSelect.nativeElement.id !== changedSelect?.id) {
+      this.collegesSelect.nativeElement.value = '';
     }
 
-    this.router.navigate([], {
-      relativeTo: this.route,
-      queryParams: { ...params, selectedOrganizations: selectedOrganizations.join(',') },
-      queryParamsHandling: 'merge'
-    });
+    if (this.departmentsSelect && this.departmentsSelect.nativeElement.id !== changedSelect?.id) {
+      this.departmentsSelect.nativeElement.value = '';
+    }
+
+    if (this.othersSelect && this.othersSelect.nativeElement.id !== changedSelect?.id) {
+      this.othersSelect.nativeElement.value = '';
+    }
+
+    this.store.dispatch(new fromSdr.SelectResourceAction('individual', { id }));
   }
 
-  public onSelectOrganization(id: any, params: Params): void {
-    const selectedOrganizations = !!params.selectedOrganizations
-      ? `${params.selectedOrganizations},${id}`
-      : id;
-
-    this.router.navigate([], {
-      relativeTo: this.route,
-      queryParams: { ...params, selectedOrganizations },
-      queryParamsHandling: 'merge'
-    });
-
-    this.store.dispatch(new fromSdr.GetOneResourceAction('individual', { id }));
-  }
-
-  public getQueryParams(params: Params, view: DataAndAnalyticsView, displayView: DisplayView): Params {
+  public getQueryParams(params: Params, view: DataAndAnalyticsView, displayView: DisplayView, orgId?: string | number): Params {
     const queryParams: Params = {
       ...params,
       ...getQueryParamsForFacets(view),
@@ -242,6 +210,10 @@ export class DataAndAnalyticsComponent implements OnInit {
       default: break;
     }
 
+    if (orgId) {
+      queryParams.selectedOrganization = orgId;
+    }
+
     return queryParams;
   }
 
@@ -249,23 +221,25 @@ export class DataAndAnalyticsComponent implements OnInit {
     this.labelSubject.next(label);
   }
 
-  private filterSubOrganization(organization: any, types: string[]): any[] {
-    const subOrganizations = !!organization.hasSubOrganizations
-      ? organization.hasSubOrganizations
-      : [];
+  private getOrganizationsByTypes(types: string[]): Observable<Individual[]> {
+    const filters = [{
+      field: 'type',
+      value: `(${types.join(' OR ')})`,
+      opKey: OpKey.EXPRESSION
+    }, {
+      field: 'class',
+      value: 'Organization',
+      opKey: OpKey.EQUALS
+    }];
 
-    return subOrganizations.filter(so => {
-      for (const type of types) {
-        const match = type.startsWith('!')
-          ? so.type !== type.substring(1)
-          : so.type === type;
-        if (!match) {
-          return false;
-        }
-      }
+    const page = {
+      number: 0,
+      size: 9999,
+      sort: [],
+    }
 
-      return true;
-    });
+    return this.individualRepo.search({ filters, page })
+      .pipe(map((collection) => collection._embedded.individual as Individual[]));
   }
 
 }

--- a/src/app/+data-and-analytics/data-and-analytics.component.ts
+++ b/src/app/+data-and-analytics/data-and-analytics.component.ts
@@ -97,10 +97,9 @@ export class DataAndAnalyticsComponent implements OnInit {
       filter((organization: Individual) => !!organization),
     );
 
+    // TODO: add filter select options to the data and analytic persistent view
     this.colleges = this.getOrganizationsByTypes(['College']);
-
     this.departments = this.getOrganizationsByTypes(['AcademicDepartment']);
-
     this.others = this.getOrganizationsByTypes(['AdministrativeUnit', 'AffiliatedAgency', 'Association', 'BranchCampus', 'Center', 'Hospital', 'Institute', 'Laboratory', 'Library', 'Program', 'School', 'University']);
 
     this.themeOrganizationId = this.store.pipe(

--- a/src/app/core/store/sdr/index.ts
+++ b/src/app/core/store/sdr/index.ts
@@ -13,6 +13,7 @@ export const selectAllResources = <R extends SdrResource>(name: string) => creat
 export const selectResourcesTotal = <R extends SdrResource>(name: string) => createSelector(selectSdrState<R>(name), fromSdr.selectTotal(name));
 
 export const selectResourceError = <R extends SdrResource>(name: string) => createSelector(selectSdrState<R>(name), fromSdr.getError);
+export const selectResourceIsSelecting = <R extends SdrResource>(name: string) => createSelector(selectSdrState<R>(name), fromSdr.isSelecting);
 export const selectResourceIsCounting = <R extends SdrResource>(name: string) => createSelector(selectSdrState<R>(name), fromSdr.isCounting);
 export const selectResourceIsLoading = <R extends SdrResource>(name: string) => createSelector(selectSdrState<R>(name), fromSdr.isLoading);
 export const selectResourceIsDereferencing = <R extends SdrResource>(name: string) => createSelector(selectSdrState<R>(name), fromSdr.isDereferencing);
@@ -20,6 +21,7 @@ export const selectResourceIsUpdating = <R extends SdrResource>(name: string) =>
 
 export const selectResourcesCounts = <R extends SdrResource>(name: string) => createSelector(selectSdrState<R>(name), fromSdr.getCounts);
 export const selectResourcesCountByLabel = <R extends SdrResource>(name: string, label: string) => createSelector(selectSdrState<R>(name), fromSdr.getCountByLabel(label));
+export const selectResourceSelected = <R extends SdrResource>(name: string) => createSelector(selectSdrState<R>(name), fromSdr.getSelected);
 export const selectResourcesPage = <R extends SdrResource>(name: string) => createSelector(selectSdrState<R>(name), fromSdr.getPage);
 export const selectResourcesFacets = <R extends SdrResource>(name: string) => createSelector(selectSdrState<R>(name), fromSdr.getFacets);
 export const selectResourcesLinks = <R extends SdrResource>(name: string) => createSelector(selectSdrState<R>(name), fromSdr.getLinks);
@@ -28,7 +30,7 @@ export const selectResourcesDataNetwork = <R extends SdrResource>(name: string) 
 export const selectResourcesAcademicAge = <R extends SdrResource>(name: string) => createSelector(selectSdrState<R>(name), fromSdr.getAcademicAge);
 export const selectResourcesQuantityDistribution = <R extends SdrResource>(name: string) => createSelector(selectSdrState<R>(name), fromSdr.getQuantityDistribution);
 
-export const selectResourceById = <R extends SdrResource>(name: string, id: string) => createSelector(selectResourceEntities<R>(name), (resources) => resources[id]);
+export const selectResourceById = <R extends SdrResource>(name: string, id: string | number) => createSelector(selectResourceEntities<R>(name), (resources) => resources[id]);
 
 export const selectCollectionViewByName = (collectionViewType: string, name: string) => createSelector(selectResourceEntities<CollectionView>(collectionViewType), (collectionViews) => collectionViews[name]);
 

--- a/src/app/core/store/sdr/sdr.actions.ts
+++ b/src/app/core/store/sdr/sdr.actions.ts
@@ -5,6 +5,9 @@ import { Queryable } from '../../model/request/sdr.request';
 import { Count, SdrCollection } from '../../model/sdr';
 
 export enum SdrActionTypes {
+  SELECT_RESOURCE = 'select a resource',
+  SELECT_RESOURCE_SUCCESS = 'successfully selected a resource',
+  SELECT_RESOURCE_FAILURE = 'failed selected a resource',
   GET_ALL = 'get all resources',
   GET_ALL_SUCCESS = 'sucessfully got all resources',
   GET_ALL_FAILURE = 'failed getting all resources',
@@ -61,6 +64,24 @@ export enum SdrActionTypes {
 export const getSdrAction = (actionType: SdrActionTypes, name: string): string => {
   return `[${name}] ${actionType}`;
 };
+
+export class SelectResourceAction implements Action {
+  readonly type = getSdrAction(SdrActionTypes.SELECT_RESOURCE, this.name);
+  constructor(public name: string, public payload: {
+    id: number | string,
+    queue?: Array<GetOneResourceAction>,
+  }) { }
+}
+
+export class SelectResourceSuccessAction implements Action {
+  readonly type = getSdrAction(SdrActionTypes.SELECT_RESOURCE_SUCCESS, this.name);
+  constructor(public name: string, public payload: any) { }
+}
+
+export class SelectResourceFailureAction implements Action {
+  readonly type = getSdrAction(SdrActionTypes.SELECT_RESOURCE_FAILURE, this.name);
+  constructor(public name: string, public payload: any) { }
+}
 
 export class GetAllResourcesAction implements Action {
   readonly type = getSdrAction(SdrActionTypes.GET_ALL, this.name);
@@ -141,6 +162,7 @@ export class GetOneResourceAction implements Action {
   readonly type = getSdrAction(SdrActionTypes.GET_ONE, this.name);
   constructor(public name: string, public payload: {
     id: number | string,
+    select?: boolean,
     queue?: Array<GetOneResourceAction>,
   }) { }
 }
@@ -342,6 +364,9 @@ export class ClearResourceByIdAction implements Action {
 }
 
 export type SdrActions =
+  SelectResourceAction |
+  SelectResourceSuccessAction |
+  SelectResourceFailureAction |
   GetAllResourcesAction |
   GetAllResourcesSuccessAction |
   GetAllResourcesFailureAction |

--- a/src/app/core/store/stomp/stomp.effects.ts
+++ b/src/app/core/store/stomp/stomp.effects.ts
@@ -3,7 +3,7 @@ import { Actions, createEffect, ofType, OnInitEffects } from '@ngrx/effects';
 import { Action, Store } from '@ngrx/store';
 import { StompSubscription } from '@stomp/stompjs';
 import { asapScheduler, Observable, scheduled } from 'rxjs';
-import { catchError, map, mergeMap, skipWhile, switchMap, withLatestFrom } from 'rxjs/operators';
+import { catchError, filter, map, mergeMap, skipWhile, switchMap, withLatestFrom } from 'rxjs/operators';
 
 import { AppState } from '../';
 import { AlertService } from '../../service/alert.service';
@@ -92,7 +92,7 @@ export class StompEffects implements OnInitEffects {
     ofType(fromStomp.StompActionTypes.UNSUBSCRIBE),
     map((action: fromStomp.UnsubscribeAction) => action),
     withLatestFrom(this.store),
-    skipWhile(([action, store]) => !store.stomp.subscriptions.get(action.payload.channel)),
+    filter(([action, store]) => !!store.stomp.subscriptions.get(action.payload.channel)),
     switchMap(([action, store]) =>
       scheduled([store.stomp.subscriptions.get(action.payload.channel).unsubscribe()], asapScheduler).pipe(
         map(

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -60,6 +60,9 @@
     "OTHERS": "Centers, Institutes, & Others",
     "SELECT": "- Select -",
     "DOWNLOAD": "Download",
+    "UNKNOWN": "{{value}} Unknown",
+    "NOT_SUPPORTED": "{{value}} Not Supported",
+    "RESET": "Reset Filter",
     "ACADEMIC_AGE_GROUP": {
       "MEAN": "Average academic age of affiliated researchers 🛈",
       "PUBLICATIONS": "Researchers and publications per academic age group",


### PR DESCRIPTION
# Description
Select options are now individual repo queries filtered accordingly as opposed to organization hierarchy. The breadcrumbs no longer represent a traversal through the org hierarchy and only append the organization selected. A reset filter link has been added to return to the default organization.