### PR TITLE
[Issue 360]: Subscribe, reset search form and wait 500 before closing modal

### DIFF
--- a/src/app/shared/dialog/facet-entries/facet-entries.component.ts
+++ b/src/app/shared/dialog/facet-entries/facet-entries.component.ts
@@ -131,7 +131,16 @@ export class FacetEntriesComponent implements OnDestroy, OnInit {
             type: DialogButtonType.OUTLINE_WARNING,
             label: this.translate.get('SHARED.DIALOG.FACET_ENTRIES.CANCEL'),
             action: () => {
-              this.store.dispatch(new fromDialog.CloseDialogAction());
+              this.subscriptions.push(
+                this.form.controls.filter.valueChanges.pipe(
+                  distinctUntilChanged()
+                ).subscribe(() => {
+                  setTimeout(() => {
+                    this.store.dispatch(new fromDialog.CloseDialogAction());
+                  }, 500);
+                })
+              );
+              this.form.controls.filter.setValue('');
             },
             disabled: () => scheduled([false], queueScheduler),
           },
@@ -142,7 +151,7 @@ export class FacetEntriesComponent implements OnDestroy, OnInit {
           ? 'directoryViews'
           : routerState.url.startsWith('/discovery')
             ? 'discoveryViews'
-            : 'dataAndAnalyticsViews'
+            : 'dataAndAnalyticsViews';
 
         this.collectionView = this.store.pipe(select(selectCollectionViewByName(collectionViewType, routerState.params.view)));
 


### PR DESCRIPTION
# Description
Providing patch to reduce effects of race condition on a debounced reactive form listener. The dialog component modal closing is causing the transcluded component to destroy its subscriptions. This gives it 500 seconds to reset before closing. Which is yet another hardcoded value but matches the debounce.