### PR TITLE
[Issue 363]: Prevent false positive filters query param check

### DIFF
--- a/src/app/+directory/directory.component.ts
+++ b/src/app/+directory/directory.component.ts
@@ -11,6 +11,7 @@ import { DirectoryView, DiscoveryView, Filter } from '../core/model/view';
 import { AppState } from '../core/store';
 import { selectRouterQueryParamFilters, selectRouterQueryParams } from '../core/store/router';
 import { selectAllResources, selectDiscoveryViewByClass, selectResourceById, selectResourceIsLoading, selectResourcesFacets, selectResourcesPage } from '../core/store/sdr';
+import { hasFilter } from '../shared/utilities/discovery.utility';
 import { addExportToQueryParams, getFilterField, getFilterValue, hasExport, removeFilterFromQueryParams, resetFiltersInQueryParams, showClearFilters, showFilter } from '../shared/utilities/view.utility';
 
 @Component({
@@ -82,7 +83,7 @@ export class DirectoryComponent implements OnDestroy, OnInit {
 
   public isActive(directoryView: DirectoryView, params: Params, option: string): boolean {
     const queryParams: Params = Object.assign({}, params);
-    if (queryParams.filters && queryParams.filters.indexOf(directoryView.index.field) >= 0) {
+    if (hasFilter(queryParams.filters, directoryView.index.field)) {
       return queryParams[`${directoryView.index.field}.filter`] === option;
     }
     return option === 'All';
@@ -130,7 +131,7 @@ export class DirectoryComponent implements OnDestroy, OnInit {
 
   public getDirectoryQueryParamsResetting(params: Params, directoryView: DirectoryView): Params {
     const queryParams: Params = Object.assign({}, params);
-    if (queryParams.filters && queryParams.filters.indexOf(directoryView.index.field) >= 0) {
+    if (hasFilter(queryParams.filters, directoryView.index.field)) {
       const filters = queryParams.filters.split(',')
         .map((field) => field.trim())
         .filter((field) => field !== directoryView.index.field);

--- a/src/app/core/store/sdr/sdr.effects.ts
+++ b/src/app/core/store/sdr/sdr.effects.ts
@@ -7,7 +7,7 @@ import { Observable, asapScheduler, combineLatest, defer, scheduled } from 'rxjs
 import { catchError, filter, map, mergeMap, skipWhile, switchMap, take, withLatestFrom } from 'rxjs/operators';
 
 import { AppState } from '../';
-import { FILTER_VALUE_DELIMITER, buildDateYearFilterValue, buildNumberRangeFilterValue, createSdrRequest, getFacetFilterLabel } from '../../../shared/utilities/discovery.utility';
+import { FILTER_VALUE_DELIMITER, buildDateYearFilterValue, buildNumberRangeFilterValue, createSdrRequest, getFacetFilterLabel, hasFilter } from '../../../shared/utilities/discovery.utility';
 import { removeFilterFromQueryParams } from '../../../shared/utilities/view.utility';
 import { Individual } from '../../model/discovery';
 import { injectable, repos } from '../../model/repos';
@@ -800,7 +800,7 @@ export class SdrEffects {
 
                 if (selected) {
                   sidebarSection.collapsed = false;
-                  if (sidebarItem.queryParams.filters && sidebarItem.queryParams.filters.indexOf(sdrFacet.field) >= 0) {
+                  if (hasFilter(sidebarItem.queryParams.filters, sdrFacet.field)) {
                     const queryParams: Params = Object.assign({}, sidebarItem.queryParams);
                     removeFilterFromQueryParams(queryParams, {
                       field: sdrFacet.field,
@@ -813,7 +813,7 @@ export class SdrEffects {
                   selectedFilterValues.push(filterValue);
                 } else {
                   if (sidebarItem.queryParams.filters) {
-                    if (sidebarItem.queryParams.filters.indexOf(sdrFacet.field) < 0) {
+                    if (!hasFilter(sidebarItem.queryParams.filters, sdrFacet.field)) {
                       sidebarItem.queryParams.filters += `,${sdrFacet.field}`;
                     }
                   } else {

--- a/src/app/shared/dialog/facet-entries/facet-entries.component.ts
+++ b/src/app/shared/dialog/facet-entries/facet-entries.component.ts
@@ -15,7 +15,7 @@ import { AppState } from '../../../core/store';
 import { selectRouterQueryParams, selectRouterState } from '../../../core/store/router';
 import { CustomRouterState } from '../../../core/store/router/router.reducer';
 import { selectCollectionViewByName } from '../../../core/store/sdr';
-import { FILTER_VALUE_DELIMITER, buildDateYearFilterValue, buildNumberRangeFilterValue, createSdrRequest, getFacetFilterLabel } from '../../utilities/discovery.utility';
+import { FILTER_VALUE_DELIMITER, buildDateYearFilterValue, buildNumberRangeFilterValue, createSdrRequest, getFacetFilterLabel, hasFilter } from '../../utilities/discovery.utility';
 
 import * as fromDialog from '../../../core/store/dialog/dialog.actions';
 
@@ -258,7 +258,7 @@ export class FacetEntriesComponent implements OnDestroy, OnInit {
     }
     queryParams[`${this.field}.pageNumber`] = 1;
     if (queryParams.filters && queryParams.filters.length > 0) {
-      if (queryParams.filters.indexOf(this.field) < 0) {
+      if (!hasFilter(queryParams.filters, this.field)) {
         queryParams.filters += `,${facet.field}`;
       }
     } else {

--- a/src/app/shared/utilities/discovery.utility.ts
+++ b/src/app/shared/utilities/discovery.utility.ts
@@ -8,6 +8,8 @@ import { CustomRouterState } from '../../core/store/router/router.reducer';
 
 export const FILTER_VALUE_DELIMITER = ';;';
 
+export const hasFilter = (filters: string, filter: string): boolean => filters?.trim().split(',').find(f => f === filter) !== undefined;
+
 export const buildDateYearFilterValue = (facetEntry: SdrFacetEntry): string => {
   const date = new Date(facetEntry.value);
   const year = date.getUTCFullYear();


### PR DESCRIPTION
# Description
Filters can have another filter within its string literal and cannot use string indexOf for inclusion in the filters query parameter. This PR adds a utility method to safely perform the condition and updates all locations which incur this bug.