### PR TITLE
Sprint8-396-Adjusted collection filter to find concepts

### DIFF
--- a/src/app/+display/display.component.ts
+++ b/src/app/+display/display.component.ts
@@ -127,7 +127,7 @@ export class DisplayComponent implements OnDestroy, OnInit {
             take(1),
             switchMap((individual: Individual) => {
               return this.store.pipe(
-                select(selectDiscoveryViewByClass(individual.class)),
+                select(selectDiscoveryViewByClass(individual.class, individual.type)),
                 filter((view: DiscoveryView) => view !== undefined)
               );
             })
@@ -252,7 +252,7 @@ export class DisplayComponent implements OnDestroy, OnInit {
         }
       })
     );
-  }
+}
 
   public getDisplayViewTabRoute(displayView: DisplayView, tab: DisplayTabView): string[] {
     return [displayView.name, tab.name];


### PR DESCRIPTION
# Description
Resolves #396 

Resolves issue specifically with the `Concepts` group under `Advanced Search`.

The Concepts & Awards collection filters have a similar mapping, causing Awards to generate a false positive. 

# Supporting Material
![Code_5TY844oYKC](https://github.com/user-attachments/assets/e1a05e0d-99e9-422c-b868-59d022268a22)


