### PR TITLE
Hide aside for type Publisher and external organizations

### DIFF
--- a/src/app/+display/display.component.html
+++ b/src/app/+display/display.component.html
@@ -30,7 +30,8 @@
           </div>
         </div>
       </div>
-      <div *ngIf="showAsideRight(displayView)" class="d-none d-lg-block col-lg-3 p-0">
+      <div *ngIf="showAsideRight(displayView, individual)" class="d-none d-lg-block col-lg-3 p-0">
+        aside right
         <ng-container *ngTemplateOutlet="aside"></ng-container>
       </div>
       <ng-template #aside>

--- a/src/app/+display/display.component.html
+++ b/src/app/+display/display.component.html
@@ -31,7 +31,6 @@
         </div>
       </div>
       <div *ngIf="showAsideRight(displayView, individual)" class="d-none d-lg-block col-lg-3 p-0">
-        aside right
         <ng-container *ngTemplateOutlet="aside"></ng-container>
       </div>
       <ng-template #aside>

--- a/src/app/+display/display.component.ts
+++ b/src/app/+display/display.component.ts
@@ -133,10 +133,6 @@ export class DisplayComponent implements OnDestroy, OnInit {
             })
           );
 
-          this.discoveryView.subscribe((val) => {console.log('discoveryView:', val)})
-          this.individual.subscribe((val) => {console.log('individual:', val)})
-
-
           // listen to individual changes, updating display view tabs
           this.displayView = this.store.pipe(
             select(selectResourceById('individual', params.id)),
@@ -283,10 +279,7 @@ export class DisplayComponent implements OnDestroy, OnInit {
 
     const isExcluded: Boolean = individual.type.some(type => excludeTypes.includes(type));
 
-    if (isExcluded)
-      return false;
-
-    return this.showAside(displayView) && displayView.asideLocation === Side.RIGHT;
+    return !isExcluded && this.showAside(displayView) && displayView.asideLocation === Side.RIGHT;
   }
 
   public showAside(displayView: DisplayView): boolean {

--- a/src/app/+display/display.component.ts
+++ b/src/app/+display/display.component.ts
@@ -275,11 +275,15 @@ export class DisplayComponent implements OnDestroy, OnInit {
   }
 
   public showAsideRight(displayView: DisplayView, individual: Individual): boolean {
-    const excludeTypes: Array<String> = ['Publisher', 'External Organization', 'otherUniversity'];
-
-    const isExcluded: Boolean = individual.type.some(type => excludeTypes.includes(type));
+    const isExcluded: boolean = this.excludeAsideByIndividualType(individual)
 
     return !isExcluded && this.showAside(displayView) && displayView.asideLocation === Side.RIGHT;
+  }
+
+  private excludeAsideByIndividualType(individual: Individual): boolean {
+    const excludeTypes: Array<String> = ['Publisher', 'External Organization', 'otherUniversity'];
+
+    return individual.type.some(type => excludeTypes.includes(type));
   }
 
   public showAside(displayView: DisplayView): boolean {

--- a/src/app/+display/display.component.ts
+++ b/src/app/+display/display.component.ts
@@ -133,6 +133,10 @@ export class DisplayComponent implements OnDestroy, OnInit {
             })
           );
 
+          this.discoveryView.subscribe((val) => {console.log('discoveryView:', val)})
+          this.individual.subscribe((val) => {console.log('individual:', val)})
+
+
           // listen to individual changes, updating display view tabs
           this.displayView = this.store.pipe(
             select(selectResourceById('individual', params.id)),
@@ -274,7 +278,14 @@ export class DisplayComponent implements OnDestroy, OnInit {
     return this.showAside(displayView) && displayView.asideLocation === Side.LEFT;
   }
 
-  public showAsideRight(displayView: DisplayView): boolean {
+  public showAsideRight(displayView: DisplayView, individual: Individual): boolean {
+    const excludeTypes: Array<String> = ['Publisher', 'External Organization', 'otherUniversity'];
+
+    const isExcluded: Boolean = individual.type.some(type => excludeTypes.includes(type));
+
+    if (isExcluded)
+      return false;
+
     return this.showAside(displayView) && displayView.asideLocation === Side.RIGHT;
   }
 

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -5,13 +5,13 @@
     <li class="list-inline-item" *ngIf="(isAdmin | async) === true">
       <a [routerLink]="['/admin']">{{ 'FOOTER.ADMINISTRATION' | translate }}</a>
     </li>
-    <li class="list-inline-item">
+    <li class="list-inline-item" *ngIf="(isAuthenticated | async) === false">
       <a class="link" (click)="openRegistrationDialog()">{{ 'FOOTER.REGISTRATION' | translate }}</a>
     </li>
-    <li class="list-inline-item">
+    <li class="list-inline-item" *ngIf="(isAuthenticated | async) === false">
       <a class="link" (click)="openLoginDialog()">{{ 'FOOTER.LOGIN' | translate }}</a>
     </li>
-    <li class="list-inline-item">
+    <li class="list-inline-item" *ngIf="(isAuthenticated | async) === true">
       <a class="link" (click)="logout()">{{ 'FOOTER.LOGOUT' | translate }}</a>
     </li>
     <li class="list-inline-item" *ngIf="user | async; let user">

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -5,13 +5,13 @@
     <li class="list-inline-item" *ngIf="(isAdmin | async) === true">
       <a [routerLink]="['/admin']">{{ 'FOOTER.ADMINISTRATION' | translate }}</a>
     </li>
-    <li class="list-inline-item" *ngIf="(isAuthenticated | async) === false">
+    <li class="list-inline-item">
       <a class="link" (click)="openRegistrationDialog()">{{ 'FOOTER.REGISTRATION' | translate }}</a>
     </li>
-    <li class="list-inline-item" *ngIf="(isAuthenticated | async) === false">
+    <li class="list-inline-item">
       <a class="link" (click)="openLoginDialog()">{{ 'FOOTER.LOGIN' | translate }}</a>
     </li>
-    <li class="list-inline-item" *ngIf="(isAuthenticated | async) === true">
+    <li class="list-inline-item">
       <a class="link" (click)="logout()">{{ 'FOOTER.LOGOUT' | translate }}</a>
     </li>
     <li class="list-inline-item" *ngIf="user | async; let user">


### PR DESCRIPTION
# Description
Resolves #399 
Remove the `Temporal Graph` and `Map of Science` links for resources that are: Publishers or External Organizations. The goal is to 'hide' the links for now, in case they are utilized in the future. 

# Supporting Material
Publisher Example (Updated)
![dbeaver_WxU5BtD38T](https://github.com/user-attachments/assets/3e272a1e-9ebb-4540-ade0-ee317c9ba971)
People Example (Unchanged)
![Code_IAcC41cMQl](https://github.com/user-attachments/assets/bb4585ac-197a-4d49-b72a-66124d8beb78)
College Organization Example (Unchanged)
![Code_qZDBV1oUwh](https://github.com/user-attachments/assets/f1d4065a-9532-45ac-8c1c-4584ee9f8ac2)
External College Example (Updated)
![Code_zqPjCH63oD](https://github.com/user-attachments/assets/11a58317-df3a-4e68-b70a-b0e58dc20bfc)
