### PR TITLE
Removed admin ability to view /admin routes

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -10,7 +10,7 @@ const routes: Routes = [
     loadChildren: () => import('./+admin').then((m) => m.AdminModule),
     canActivate: [AuthGuard],
     data: {
-      roles: [Role.ROLE_SUPER_ADMIN, Role.ROLE_ADMIN],
+      roles: [Role.ROLE_SUPER_ADMIN],
       tags: [{ name: 'view', content: 'Scholars Administration' }],
     },
   },

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -2,7 +2,7 @@
 <div class="footer">
   <ul class="list-inline text-center" *ngIf="footer | async; let footer">
     <li class="list-inline-item" *ngFor="let link of footer.links"><a href="{{link.uri}}">{{link.label}}</a></li>
-    <li class="list-inline-item" *ngIf="(isAdmin | async) === true">
+    <li class="list-inline-item" *ngIf="(isSuperAdmin | async) === true">
       <a [routerLink]="['/admin']">{{ 'FOOTER.ADMINISTRATION' | translate }}</a>
     </li>
     <li class="list-inline-item" *ngIf="(isAuthenticated | async) === false">

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -23,7 +23,7 @@ export class FooterComponent implements OnInit {
 
   public isAuthenticated: Observable<boolean>;
 
-  public isAdmin: Observable<boolean>;
+  public isSuperAdmin: Observable<boolean>;
 
   public user: Observable<User>;
 
@@ -38,7 +38,7 @@ export class FooterComponent implements OnInit {
 
   ngOnInit() {
     this.isAuthenticated = this.store.pipe(select(selectIsAuthenticated));
-    this.isAdmin = this.store.pipe(select(selectHasRole(Role.ROLE_ADMIN)));
+    this.isSuperAdmin = this.store.pipe(select(selectHasRole(Role.ROLE_SUPER_ADMIN)));
     this.user = this.store.pipe(select(selectUser));
     this.footer = this.store.pipe(
       select(selectActiveThemeFooter),


### PR DESCRIPTION
# Description

Resolves #411 

- Removed `administrator` role ability to view `/admin` routes
- Removed `Administrators` link from footer for all users but `Super Admin`
