### PR TITLE
[Issue 394] Use single organization approach in center.

### DIFF
--- a/src/app/+data-and-analytics/data-and-analytics.component.html
+++ b/src/app/+data-and-analytics/data-and-analytics.component.html
@@ -86,30 +86,12 @@
               </div>
 
               <div class="row p-1">
-                <div class="col-4" *ngIf="colleges | async; let colleges">
+                <div class="col-12" *ngIf="orgs | async; let orgs">
                   <div class="form-group">
-                    <label class="font-weight-bold">{{ 'DATA_AND_ANALYTICS.COLLEGES_AND_SCHOOLS' | translate }}</label>
-                    <select #collegesSelect id="collegesSelect" class="form-control" ngModel (ngModelChange)="onSelectOrganization($event, params, collegesSelect)">
+                    <label class="font-weight-bold">{{ 'DATA_AND_ANALYTICS.ORGANIZATIONS' | translate }}</label>
+                    <select #orgsSelect id="orgsSelect" class="form-control" ngModel (ngModelChange)="onSelectOrganization($event, params, orgsSelect)">
                       <option value="" disabled selected>{{ 'DATA_AND_ANALYTICS.SELECT' | translate }}</option>
-                      <option *ngFor="let so of colleges" [ngValue]="so.id">{{ so.name }}</option>
-                    </select>
-                  </div>
-                </div>
-                <div class="col-4" *ngIf="departments | async; let departments">
-                  <div class="form-group">
-                    <label class="font-weight-bold">{{ 'DATA_AND_ANALYTICS.DEPARTMENTS' | translate }}</label>
-                    <select #departmentsSelect id="departmentsSelect" class="form-control" ngModel (ngModelChange)="onSelectOrganization($event, params, departmentsSelect)">
-                      <option value="" disabled selected>{{ 'DATA_AND_ANALYTICS.SELECT' | translate }}</option>
-                      <option *ngFor="let so of departments" [ngValue]="so.id">{{ so.name }}</option>
-                    </select>
-                  </div>
-                </div>
-                <div class="col-4" *ngIf="others | async; let others">
-                  <div class="form-group">
-                    <label class="font-weight-bold">{{ 'DATA_AND_ANALYTICS.OTHERS' | translate }}</label>
-                    <select #othersSelect id="othersSelect" class="form-control" ngModel (ngModelChange)="onSelectOrganization($event, params, othersSelect)">
-                      <option value="" disabled selected>{{ 'DATA_AND_ANALYTICS.SELECT' | translate }}</option>
-                      <option *ngFor="let so of others" [ngValue]="so.id">{{ so.name }}</option>
+                      <option *ngFor="let so of orgs" [ngValue]="so.id">{{ so.name }}</option>
                     </select>
                   </div>
                 </div>

--- a/src/app/+data-and-analytics/data-and-analytics.component.ts
+++ b/src/app/+data-and-analytics/data-and-analytics.component.ts
@@ -27,9 +27,7 @@ import * as fromSidebar from '../core/store/sidebar/sidebar.actions';
 })
 export class DataAndAnalyticsComponent implements OnInit {
 
-  @ViewChild('collegesSelect') collegesSelect: ElementRef<HTMLSelectElement>;
-  @ViewChild('departmentsSelect') departmentsSelect: ElementRef<HTMLSelectElement>;
-  @ViewChild('othersSelect') othersSelect: ElementRef<HTMLSelectElement>;
+  @ViewChild('orgsSelect') orgsSelect: ElementRef<HTMLSelectElement>;
 
   public displayView: Observable<DisplayView>;
 
@@ -53,11 +51,7 @@ export class DataAndAnalyticsComponent implements OnInit {
 
   public labelSubject: BehaviorSubject<string>;
 
-  public colleges: Observable<Individual[]>;
-
-  public departments: Observable<Individual[]>;
-
-  public others: Observable<Individual[]>;
+  public orgs: Observable<Individual[]>;
 
   public get label(): Observable<string> {
     return this.labelSubject.asObservable();
@@ -118,24 +112,20 @@ export class DataAndAnalyticsComponent implements OnInit {
     // University (11)
     // External Organization (1453) *
     // * should not be in any select options
-    this.colleges = this.getOrganizationsByTypes([
-      'College',
-      'School',
-    ]);
-    this.departments = this.getOrganizationsByTypes([
-      'AcademicDepartment'
-    ]);
-    this.others = this.getOrganizationsByTypes([
+    this.orgs = this.getOrganizationsByTypes([
+      'AcademicDepartment',
       'AffiliatedAgency',
       'Association',
       'BranchCampus',
       'Center',
+      'College',
       'Hospital',
       'Institute',
       'Laboratory',
       'Library',
       'Program',
-      'University'
+      'School',
+      'University',
     ]);
 
     this.themeOrganization = this.store.pipe(
@@ -219,16 +209,8 @@ export class DataAndAnalyticsComponent implements OnInit {
       queryParamsHandling: 'merge'
     });
 
-    if (this.collegesSelect && this.collegesSelect.nativeElement.id !== changedSelect?.id) {
-      this.collegesSelect.nativeElement.value = '';
-    }
-
-    if (this.departmentsSelect && this.departmentsSelect.nativeElement.id !== changedSelect?.id) {
-      this.departmentsSelect.nativeElement.value = '';
-    }
-
-    if (this.othersSelect && this.othersSelect.nativeElement.id !== changedSelect?.id) {
-      this.othersSelect.nativeElement.value = '';
+    if (this.orgsSelect && this.orgsSelect.nativeElement.id !== changedSelect?.id) {
+      this.orgsSelect.nativeElement.value = '';
     }
 
     this.store.dispatch(new fromSdr.SelectResourceAction('individual', { id }));
@@ -280,7 +262,7 @@ export class DataAndAnalyticsComponent implements OnInit {
     }
 
     return this.individualRepo.search({ filters, page })
-      .pipe(map((collection) => collection._embedded.individual as Individual[]));
+      .pipe(map(collection => (collection._embedded.individual as Individual[]).sort((a, b) => a.name.localeCompare(b.name))));
   }
 
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -53,11 +53,9 @@
   "DATA_AND_ANALYTICS": {
     "LABEL": "Data & Analytics",
     "ORGANIZATION": "Organization",
+    "ORGANIZATIONS": "Organizations",
     "TIME_PERIOD": "Time Period",
     "PROFILE_SUMMARIES": "Profile Summaries for the {{timePeriod}}",
-    "COLLEGES_AND_SCHOOLS": "Colleges & Schools",
-    "DEPARTMENTS": "Departments",
-    "OTHERS": "Centers, Institutes, & Others",
     "SELECT": "- Select -",
     "DOWNLOAD": "Download",
     "UNKNOWN": "{{value}} Unknown",


### PR DESCRIPTION
# Description

Partially resolves #394 .

This is a short term solution that merges the three select lists into a single, sorted, organizations list.

The naming of `orgs` is chosen over `organizations` to avoid conflicts with the use of `organization` for other aspects of the view.

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# Testing Procedures

Compared results side-by-side with alternative server to confirm that the lists results in the same view and that the graphs update accordingly.

Also tested switching to the parent page to trigger the default A&M display to confirm that this does properly clear the select list selection.
