### PR TITLE
[Issue 409] Implement message when there is no information.

### DIFF
--- a/src/app/+display/tab/tab.component.html
+++ b/src/app/+display/tab/tab.component.html
@@ -1,7 +1,15 @@
 <div *ngIf="individual | async; let individual" class="tab-content">
   <div *ngIf="tab | async; let tab" class="tab-pane active">
-    <div class="ml-3 mr-3 mt-3 card" *ngFor="let section of getSectionsToShow(tab, individual)">
-      <scholars-section [section]="section" [display]="display" [individual]="individual"></scholars-section>
+    <div *ngIf="getSectionsToShow(tab, individual) as sections ; else no_content">
+      <div class="ml-3 mr-3 mt-3 card" *ngFor="let section of sections">
+        <scholars-section [section]="section" [display]="display" [individual]="individual"></scholars-section>
+      </div>
     </div>
+    <ng-template #no_content>
+      <div class="ml-3 mr-3 mt-3 card">
+        <div class="card-header font-weight-bold text-primary text-capitalize">{{ 'DISPLAY.TAB.NO_CONTENT_TITLE' | translate }}</div>
+        <div class="card-body">{{ 'DISPLAY.TAB.NO_CONTENT_TEXT' | translate }}</div>
+      </div>
+    </ng-template>
   </div>
 </div>

--- a/src/app/+display/tab/tab.component.ts
+++ b/src/app/+display/tab/tab.component.ts
@@ -76,7 +76,8 @@ export class TabComponent implements OnDestroy, OnInit {
   }
 
   public getSectionsToShow(tab: DisplayTabView, individual: Individual): DisplayTabSectionView[] {
-    return sectionsToShow(tab.sections, individual);
+    const sections = sectionsToShow(tab.sections, individual);
+    return sections?.length ? sections : undefined;
   }
 
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -83,6 +83,10 @@
     "EMBEDDABLE": {
       "LABEL": "Embeddable",
       "COPIED": "Embeddable snippet copied!"
+    },
+    "TAB": {
+      "NO_CONTENT_TITLE": "No Information",
+      "NO_CONTENT_TEXT": "There is no information to display yet."
     }
   },
   "VISUALIZATION": {


### PR DESCRIPTION
resolves #409

When the tab section array list is empty, no content is displayed. The component html template code is calling a function to get the section array list.

I want to avoid calling that function multiple times. Get the section array list as a `sections` variable via an `ngIf`. The `ngFor` can then loop over the `sections` variable.

The `sections?.length` is now being tested in the calling function so that I can return either a full object on nothing on an empty array. This helps avoid the need for performing a `?.length` inside the html template code. The `ngIf` does not handle assigning a value and operating on a member of that property very well.

That is to say this is not possible while passing sections as an array as far as I can tell:
```html
<div *ngIf="getSectionsToShow(tab, individual)?.length as sections ; else no_content">
```
The `?.length` would end up being added as sections. Adding parenthesis around this also does not work:
```html
<div *ngIf="(getSectionsToShow(tab, individual) as sections)?.length ; else no_content">
```

# Description

Please include a summary of the changes. Please also include relevant motivation and context. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing Procedures

Viewed pages before and after.
Viewed pages with expected populated sections and with expected no sections.
