### PR TITLE
[Issue 420] Invert boolean logic to fix the links.

### DIFF
--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -5,10 +5,10 @@
     <li class="list-inline-item" *ngIf="(isAdmin | async) === true">
       <a [routerLink]="['/admin']">{{ 'FOOTER.ADMINISTRATION' | translate }}</a>
     </li>
-    <li class="list-inline-item" *ngIf="(isAuthenticated | async) === false">
+    <li class="list-inline-item" *ngIf="(isAuthenticated | async) !== true">
       <a class="link" (click)="openRegistrationDialog()">{{ 'FOOTER.REGISTRATION' | translate }}</a>
     </li>
-    <li class="list-inline-item" *ngIf="(isAuthenticated | async) === false">
+    <li class="list-inline-item" *ngIf="(isAuthenticated | async) !== true">
       <a class="link" (click)="openLoginDialog()">{{ 'FOOTER.LOGIN' | translate }}</a>
     </li>
     <li class="list-inline-item" *ngIf="(isAuthenticated | async) === true">


### PR DESCRIPTION
# Description
Resolves #420 .

While logged out, the boolean observable is somehow an empty string.

Using the following in the HTML shows the value:
```html
<div>DEBUG: isauth = {{isAuthenticated | async}}</div>
```

An alternative way to review the value of `isAuthenticated` is to do modify the ts file using the following snippets:

```ts
  import { Observable, tap } from 'rxjs';

  public debug: any;

  this.isAuthenticated.pipe(
    tap(x => this.debug = x)
  ).subscribe(x => console.log(x));

  console.log("DEBUG: ngoninit this.isAuthenticated=", this.debug, typeof this.debug);

  console.log("DEBUG: on login this.isAuthenticated=", this.debug, typeof this.debug);

  console.log("DEBUG: on logout this.isAuthenticated=", this.debug, typeof this.debug);
```

This produced messages on login popup like this:
```
DEBUG: on login this.isAuthenticated= <empty string> string
```

This produced message on logout like this:
```
DEBUG: on logout this.isAuthenticated= true boolean
```

There might be a bigger issue to resolve here in regards to preventing an empty string.
The goal of this change is just to ensure the admin register and admin login links still work.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing Procedures

Manually logged in and out.
Used the example snippets to observe the variable values.
