### PR TITLE
410: Manually override pagination colors to enforce color contrast ratio.

### DIFF
--- a/src/app/shared/dialog/dialog.component.scss
+++ b/src/app/shared/dialog/dialog.component.scss
@@ -6,4 +6,32 @@
       color: var(--dialog-header-color);
     }
   }
+
+  .modal-body {
+    ::ng-deep .pagination {
+
+      .page-item .page-link {
+        background-color: #ffffff;
+        color: #0056b3;
+      }
+
+      .page-item .page-link:hover {
+        background-color: #e9ecef;
+        color: #004a99;
+      }
+
+      .page-item.active .page-link {
+        background-color: #0056b3;
+        border-color: #0056b3;
+        color: #ffffff;
+      }
+
+      .page-item.active .page-link:focus,
+      .page-item.active .page-link:hover {
+        background-color: #003b7a;
+        border-color: #003b7a;
+        color: #ffffff;
+      }
+    }
+  }
 }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -12,8 +12,8 @@ $scholars-theme: ();
 $scholars-theme: map-merge(
   (
     "accent": #ffc222,
-    "link-color": #007bff,
-    "link-color-hover": #0056b3,
+    "link-color": #0056b3,
+    "link-color-hover": #004a99,
 
     "navigation-background-color": #ededed,
     "navigation-color": #3c0000,


### PR DESCRIPTION
# Description

Part of resolving https://github.com/TAMULib/scholars-angular/issues/410 .

This handles additional areas missed by this commit 59c5735d447652124525ae8129fc603a48688a54.

The `::deep` is necessary for the dialog because the ngb-pagination is in a different scope.

The global link colors use too light of a blue according to the scanners. Change the color to a darker color.
The hover link is made darker to preserve the behavior of being darker on hover.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing Procedures

Used WebAIM Wave browser extension.