### PR TITLE
Filter field crashes undefined

### DIFF
--- a/src/app/shared/utilities/view.utility.ts
+++ b/src/app/shared/utilities/view.utility.ts
@@ -169,7 +169,7 @@ const showClearFilters = (collectionView: CollectionView, filters: Filter[]): bo
 };
 
 const getFilterField = (collectionView: CollectionView, actualFilter: Filter): string => {
-  return collectionView.facets.find(f => f.field === actualFilter.field).name;
+  return collectionView.facets.find(f => f.field === actualFilter.field)?.name;
 };
 
 const getFilterValue = (collectionView: CollectionView, actualFilter: Filter): string => {


### PR DESCRIPTION
# Description

The filterField() crashes on undefined when the find() returns no results.
The `view.utility.ts` has this block of code:
```
const getFilterField = (collectionView: CollectionView, actualFilter: Filter): string => {
  return collectionView.facets.find(f => f.field === actualFilter.field).name;
};
```

That code assumes that the facet will always have a correct find.
So, it has a NULL/undefined error when .name is not found.
Then the entire page/site crashes and is unusable when this happens.

An easy fix is just to use the `?.` instead of `.`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing Procedures

Manual inspection and testing.
