### PR TITLE
Issue #427: Replace data and analytic organization selection with typeahead

### DIFF
--- a/src/app/+data-and-analytics/data-and-analytics.component.html
+++ b/src/app/+data-and-analytics/data-and-analytics.component.html
@@ -93,7 +93,7 @@
                       id="typeahead-organizations"
                       type="text"
                       class="form-control"
-                      [(ngModel)]="model"
+                      [(ngModel)]="model.term"
                       [ngbTypeahead]="search"
                       (selectItem)="onSelectOrganization($event, params)"
                       [resultFormatter]="formatter"

--- a/src/app/+data-and-analytics/data-and-analytics.component.html
+++ b/src/app/+data-and-analytics/data-and-analytics.component.html
@@ -88,11 +88,16 @@
               <div class="row p-1">
                 <div class="col-12" *ngIf="organizations | async; let organizations">
                   <div class="form-group">
-                    <label class="font-weight-bold">{{ 'DATA_AND_ANALYTICS.ORGANIZATIONS' | translate }}</label>
-                    <select #organizationsSelect id="organizationsSelect" class="form-control" ngModel (ngModelChange)="onSelectOrganization($event, params, organizationsSelect)">
-                      <option value="" disabled selected>{{ 'DATA_AND_ANALYTICS.SELECT' | translate }}</option>
-                      <option *ngFor="let so of organizations" [ngValue]="so.id">{{ so.name }}</option>
-                    </select>
+                    <label class="font-weight-bold" for="typeahead-organizations">{{ 'DATA_AND_ANALYTICS.ORGANIZATIONS' | translate }}</label>
+                    <input
+                      id="typeahead-organizations"
+                      type="text"
+                      class="form-control"
+                      [(ngModel)]="model"
+                      [ngbTypeahead]="search"
+                      (selectItem)="onSelectOrganization($event, params)"
+                      [resultFormatter]="formatter"
+                      [inputFormatter]="formatter"/>
                   </div>
                 </div>
               </div>

--- a/src/app/+data-and-analytics/data-and-analytics.component.scss
+++ b/src/app/+data-and-analytics/data-and-analytics.component.scss
@@ -1,3 +1,10 @@
+:host ::ng-deep {
+  ngb-typeahead-window.dropdown-menu {
+    max-height: 500px;
+    overflow-y: auto;
+  }
+}
+
 :host {
   width: 100%;
   .card-columns {

--- a/src/app/+data-and-analytics/data-and-analytics.component.ts
+++ b/src/app/+data-and-analytics/data-and-analytics.component.ts
@@ -70,6 +70,9 @@ export class DataAndAnalyticsComponent implements OnInit {
     this.labelSubject = new BehaviorSubject<string>('');
     this.organizationsSubject = new BehaviorSubject<Individual[]>([]);
     this.organizations = this.organizationsSubject.asObservable();
+    this.model = {
+      term: '',
+    };
   }
 
   ngOnInit(): void {
@@ -233,6 +236,8 @@ export class DataAndAnalyticsComponent implements OnInit {
       queryParams: { ...params, selectedOrganization: id },
       queryParamsHandling: 'merge'
     });
+
+    this.model.term = '';
 
     this.store.dispatch(new fromSdr.SelectResourceAction('individual', { id }));
   }

--- a/src/app/+data-and-analytics/data-and-analytics.component.ts
+++ b/src/app/+data-and-analytics/data-and-analytics.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { Store, select } from '@ngrx/store';
-import { BehaviorSubject, Observable, combineLatest, filter, map, take, withLatestFrom } from 'rxjs';
+import { BehaviorSubject, Observable, OperatorFunction, combineLatest, debounceTime, distinctUntilChanged, filter, map, take, withLatestFrom } from 'rxjs';
 
 import { Individual } from '../core/model/discovery';
 import { IndividualRepo } from '../core/model/discovery/repo/individual.repo';
@@ -29,6 +29,8 @@ export class DataAndAnalyticsComponent implements OnInit {
 
   @ViewChild('organizationSelect') organizationsSelect: ElementRef<HTMLSelectElement>;
 
+  public model: any;
+
   public displayView: Observable<DisplayView>;
 
   public dataAndAnalyticsView: Observable<DataAndAnalyticsView>;
@@ -51,6 +53,8 @@ export class DataAndAnalyticsComponent implements OnInit {
 
   public labelSubject: BehaviorSubject<string>;
 
+  public organizationsSubject: BehaviorSubject<Individual[]>;
+
   public organizations: Observable<Individual[]>;
 
   public get label(): Observable<string> {
@@ -64,6 +68,8 @@ export class DataAndAnalyticsComponent implements OnInit {
     private individualRepo: IndividualRepo,
   ) {
     this.labelSubject = new BehaviorSubject<string>('');
+    this.organizationsSubject = new BehaviorSubject<Individual[]>([]);
+    this.organizations = this.organizationsSubject.asObservable();
   }
 
   ngOnInit(): void {
@@ -112,7 +118,7 @@ export class DataAndAnalyticsComponent implements OnInit {
     // University (11)
     // External Organization (1453) *
     // * should not be in any select options
-    this.organizations = this.getOrganizationsByTypes([
+    this.getOrganizationsByTypes([
       'AcademicDepartment',
       'AffiliatedAgency',
       'Association',
@@ -126,7 +132,9 @@ export class DataAndAnalyticsComponent implements OnInit {
       'Program',
       'School',
       'University',
-    ]);
+    ]).pipe(take(1)).subscribe((organizations: Individual[]) => {
+      this.organizationsSubject.next(organizations);
+    });
 
     this.themeOrganization = this.store.pipe(
       select(selectActiveThemeOrganization),
@@ -201,17 +209,30 @@ export class DataAndAnalyticsComponent implements OnInit {
     return index;
   }
 
-  public onSelectOrganization(id: any, params: Params, changedSelect?: any): void {
+  public search: OperatorFunction<string, readonly Individual[]> = (text: Observable<string>) => {
+    return text.pipe(
+      distinctUntilChanged(),
+      map((term) => this.organizationsSubject.value
+        .filter(org => org.name.toLowerCase().includes(term.toLowerCase()))
+      )
+    );
+  }
+
+  public formatter = (organization: Individual) => organization.name;
+
+  public onSelectOrganization(event: any, params: Params): void {
+    let id = event;
+
+    if (event.hasOwnProperty('item')) {
+      const { item } = event;
+      id = item.id;
+    }
 
     this.router.navigate([], {
       relativeTo: this.route,
       queryParams: { ...params, selectedOrganization: id },
       queryParamsHandling: 'merge'
     });
-
-    if (this.organizationsSelect && this.organizationsSelect.nativeElement.id !== changedSelect?.id) {
-      this.organizationsSelect.nativeElement.value = '';
-    }
 
     this.store.dispatch(new fromSdr.SelectResourceAction('individual', { id }));
   }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -48,7 +48,7 @@ export class AppComponent implements OnInit {
   public clickEvent(event): void {
     if (this.isPlatformBrowser) {
       const target = this.findLinkTarget(event.target, 1);
-      if (target.href && target.href.indexOf(target.baseURI) >= 0) {
+      if (target?.href && target.href.indexOf(target.baseURI) >= 0) {
         const path = target.href.replace(target.baseURI, '');
         if (path.length > 0 && !path.startsWith('mailto:') && !path.startsWith('tel:')) {
           this.store.dispatch(new fromRouter.Link({ url: path }));
@@ -72,7 +72,7 @@ export class AppComponent implements OnInit {
   }
 
   private findLinkTarget(target: any, depth: number): any {
-    return target.href ? target : depth < 3 ? this.findLinkTarget(target.parentElement, ++depth) : target;
+    return target?.href ? target : depth < 3 ? this.findLinkTarget(target.parentElement, ++depth) : target;
   }
 
 }

--- a/src/app/shared/sidebar/sidebar.component.scss
+++ b/src/app/shared/sidebar/sidebar.component.scss
@@ -41,7 +41,6 @@
       margin-left: 0px;
     }
   }
-
 }
 
 ::ng-deep {

--- a/src/app/shared/sidebar/sidebar.component.scss
+++ b/src/app/shared/sidebar/sidebar.component.scss
@@ -39,10 +39,9 @@
     }
     .content {
       margin-left: 0px;
-      overflow: hidden;
     }
   }
-  
+
 }
 
 ::ng-deep {


### PR DESCRIPTION
Resolves #427 

# Description

Replaced select options with ng-bootstrap typeahead.

## Type of change

- [x] New feature (non-breaking change which adds functionality)


