### PR TITLE
Resolved "Missing Translation" bug on d3 graph header

### DIFF
--- a/src/app/+data-and-analytics/frequency-graph/frequency-graph.component.ts
+++ b/src/app/+data-and-analytics/frequency-graph/frequency-graph.component.ts
@@ -321,7 +321,7 @@ export class FrequencyGraphComponent implements OnInit, OnChanges, OnDestroy {
   public getFilter(organization: any): string {
     return this.translate.instant(organization?.hasSubOrganizations?.length > 1
       ? 'DATA_AND_ANALYTICS.FREQUENCY_GRAPH.ORGANIZATIONS_AND_PEOPLE'
-      : 'DATA_AND_ANALYTICS.FREQUENCY_GRAPH.FILTER_VALUES.PEOPLE');
+      : 'DATA_AND_ANALYTICS.FREQUENCY_GRAPH.PEOPLE');
   }
 
   private loadFacets(organization: Individual): void {


### PR DESCRIPTION
# Description

Resolved incorrectly named translation for the d3 frequency graph in data and analytics portion.

The issue was occurring whenever a selected organization had no suborganizations, and only people. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
