### PR TITLE
Citation metrics now rendering.

### DIFF
--- a/src/app/shared/result-view/result-view.component.ts
+++ b/src/app/shared/result-view/result-view.component.ts
@@ -25,9 +25,9 @@ export class ResultViewComponent implements OnInit {
     if (isPlatformBrowser(this.platformId)) {
       setTimeout(() => {
         // tslint:disable-next-line: no-string-literal
-        window['_altmetric_embed_init']();
+        window['_altmetric_embed_init']?.();
         // tslint:disable-next-line: no-string-literal
-        window['__dimensions_embed'].addBadges();
+        window['__dimensions_embed']?.addBadges();
       });
     }
   }

--- a/src/app/shared/utilities/view.utility.ts
+++ b/src/app/shared/utilities/view.utility.ts
@@ -263,9 +263,9 @@ const loadBadges = (platformId: string): void => {
   if (isPlatformBrowser(platformId)) {
     setTimeout(() => {
       // tslint:disable-next-line: no-string-literal
-      window['_altmetric_embed_init']();
+      window['_altmetric_embed_init']?.();
       // tslint:disable-next-line: no-string-literal
-      window['__dimensions_embed'].addBadges();
+      window['__dimensions_embed']?.addBadges();
     }, 250);
   }
 };


### PR DESCRIPTION
Resolves #501 

# Description

hotfix to render the citation metrics in the `Scholarly Works` for an individual with Publications.
Note that the url is no longer working and thats why the alt_metric function is not found.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing Procedures

Verified on local set up, labs and demos
<img width="980" height="1238" alt="Screenshot 2025-11-12 at 4 43 18 PM" src="https://github.com/user-attachments/assets/495d91e8-d05f-4086-b8d5-e88028e2cf40" />

