### PR TITLE
504 fix share icon position

### DIFF
--- a/src/app/+display/section/section.component.html
+++ b/src/app/+display/section/section.component.html
@@ -1,6 +1,5 @@
 <div class="card-header font-weight-bold text-primary text-capitalize">
-  <div *ngIf="queryParams | async; let queryParams">
-  <div class="container mt-2" >
+  <div *ngIf="queryParams | async; let queryParams" class="container mt-2">
     <div class="headers-row row flex-column-reverse flex-md-row">
       <div class="col-md-8">
         <span id="sidebar-title">{{ section.name }}</span>
@@ -12,23 +11,20 @@
             <span>{{ 'DIRECTORY.EXPORT' | translate }}</span>
           </a>
         </span>
-      </div>
-    </div>
-  </div>
-</div>
-<div class="float-right" *ngIf="section.shared">
-    <div class="embed-dropdown d-inline-block" placement="bottom-right" ngbDropdown>
-      <i class="fa fa-lg fa-share-alt" ngbDropdownToggle ></i>
-      <div class="dropdown-menu" ngbDropdownMenu>
-        <div class="form-group col-12">
-          <label>{{ "DISPLAY.EMBEDDABLE.LABEL" | translate }}</label>
-          <div class="input-group">
-            <textarea class="form-control" type="text" rows="4" ng-bind-html [value]="getEmbedSnippet()" #embedCode></textarea>
-            <span class="input-group-btn ml-2">
-              <i class="fa fa-lg fa-copy" (click)="copyToClipBoard(embedCode, tooltip)" triggers="click" placement="top-left" ngbTooltip="{{ 'DISPLAY.EMBEDDABLE.COPIED' | translate }}" #tooltip="ngbTooltip"></i>
-            </span>
+        <span *ngIf="section.shared" class="embed-dropdown d-inline-block" placement="bottom-right" ngbDropdown>
+          <i class="fa fa-lg fa-share-alt" ngbDropdownToggle></i>
+          <div class="dropdown-menu" ngbDropdownMenu>
+            <div class="form-group col-12">
+              <label>{{ "DISPLAY.EMBEDDABLE.LABEL" | translate }}</label>
+              <div class="input-group">
+                <textarea class="form-control" rows="4" [value]="getEmbedSnippet()" #embedCode></textarea>
+                <span class="input-group-btn ml-2">
+                  <i class="fa fa-lg fa-copy" (click)="copyToClipBoard(embedCode, tooltip)" triggers="click" ngbTooltip="{{ 'DISPLAY.EMBEDDABLE.COPIED' | translate }}" #tooltip="ngbTooltip"></i>
+                </span>
+              </div>
+            </div>
           </div>
-        </div>
+        </span>
       </div>
     </div>
   </div>

--- a/src/app/+display/section/section.component.scss
+++ b/src/app/+display/section/section.component.scss
@@ -1,41 +1,45 @@
 :host {
   width: 100%;
-    .headers-row {
-    .column-export {
-      .btn {
-        color: var(--sidebar-button-color);
-        background-color: var(--sidebar-button-background-color);
-        border: 1px solid var(--sidebar-button-border-color);
-        font-size: 0.9em;
-        padding: 5px 10px 4px;
-        .fa {
-          padding-right: 0.3em;
-        }
+
+  .headers-row .col-md-4 {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .column-export {
+    .btn {
+      color: var(--sidebar-button-color);
+      background-color: var(--sidebar-button-background-color);
+      border: 1px solid var(--sidebar-button-border-color);
+      font-size: 0.9em;
+      padding: 3px 10px 4px;
+      .fa {
+        padding-right: 0.3em;
       }
-      .btn:active,
-      .btn:hover {
-        color: var(--sidebar-button-hover-color);
-        background-color: var(--sidebar-button-hover-background-color);
-      }
-      .btn:focus {
-        box-shadow: 0 0 0 0.2rem var(--sidebar-button-focus-shadow-color);
-      }
+    }
+    .btn:hover,
+    .btn:active {
+      color: var(--sidebar-button-hover-color);
+      background-color: var(--sidebar-button-hover-background-color);
+    }
+    .btn:focus {
+      box-shadow: 0 0 0 0.2rem var(--sidebar-button-focus-shadow-color);
     }
   }
   .embed-dropdown {
     .dropdown-menu {
       min-width: 450px;
     }
-
     .dropdown-toggle::after {
       display: none;
     }
-
     .fa-share-alt {
       padding: 5px;
     }
-
     .fa-copy:hover,
+    .fa-share-alt
     .fa-share-alt:hover {
       cursor: pointer;
     }


### PR DESCRIPTION
# Description

The export button & share icon buttons belong in the same horizontal section area.

The shared link icon was in a separate block below the card header, causing the misalignment.

So moved it inside the card header template and used flex alignment to resolve this.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing Procedures

Tested this on local set up as shown in the attachment below: split screen layout to show the export button and the shared icon link on the left side  - both reside within the card header section.
<img width="1747" height="915" alt="Screenshot 2025-11-14 at 11 51 56 AM" src="https://github.com/user-attachments/assets/fcfe784b-a207-480e-a604-79cb4af13c04" />
