### PR TITLE
Profile sumaries download fix on org change

### DIFF
--- a/src/app/+data-and-analytics/profile-summaries-export/profile-summaries-export.component.html
+++ b/src/app/+data-and-analytics/profile-summaries-export/profile-summaries-export.component.html
@@ -1,5 +1,5 @@
 <div class="container mb-1 selectedProfile" *ngIf="getSelectedExportView() | async; let selected">
- <div class="col-12" *ngIf="organization as organization">
+  <div class="col-12" *ngIf="organization as organization">
     <div class="mb-1" *ngIf="organization.people && organization.people.length > 0">
       <div class="d-flex justify-content-between align-items-center mb-2">
         <div class="form-check">
@@ -38,6 +38,5 @@
       </ul>
       <input type="hidden" [value]="(selectedPeople | async) | json" name="selectedPeople" />
     </div>
- </div>
- </div>
- 
+  </div>
+</div>

--- a/src/app/+data-and-analytics/profile-summaries-export/profile-summaries-export.component.html
+++ b/src/app/+data-and-analytics/profile-summaries-export/profile-summaries-export.component.html
@@ -29,7 +29,7 @@
               id="selected-profile"
               type="checkbox"
               class="form-check-input selected-profile-checkbox"
-              [checked]="(selectedPeople | async)?.person"
+              [checked]="isPersonSelected(person)"
               (change)="onSelectPerson($event, person)"
             />
             <span class="font-weight-normal">{{ person.label }} - {{ person.title }}</span>
@@ -40,3 +40,4 @@
     </div>
  </div>
  </div>
+ 

--- a/src/app/+data-and-analytics/profile-summaries-export/profile-summaries-export.component.ts
+++ b/src/app/+data-and-analytics/profile-summaries-export/profile-summaries-export.component.ts
@@ -129,8 +129,6 @@ export class ProfileSummariesExportComponent implements OnDestroy, OnChanges, On
 
   public onSelectAll(event: Event, organization: any): void {
     const currentOrgIds = (organization.people || []).map(p => p.id);
-    console.log(currentOrgIds);
-    console.log(organization.name);
     const checked = (event.target as HTMLInputElement).checked;
     const people = organization.people || [];
     if (checked) {

--- a/src/app/+data-and-analytics/profile-summaries-export/profile-summaries-export.component.ts
+++ b/src/app/+data-and-analytics/profile-summaries-export/profile-summaries-export.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Inject, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Inject, OnDestroy, OnInit, Output, OnChanges, SimpleChanges } from '@angular/core';
 import { ActivatedRoute, Params } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
@@ -18,7 +18,7 @@ import * as fromSidebar from '../../core/store/sidebar/sidebar.actions';
   templateUrl: './profile-summaries-export.component.html',
   styleUrls: ['./profile-summaries-export.component.scss']
 })
-export class ProfileSummariesExportComponent implements OnDestroy, OnInit {
+export class ProfileSummariesExportComponent implements OnDestroy, OnChanges, OnInit {
 
   @Input()
   public organization: Individual;
@@ -73,6 +73,15 @@ export class ProfileSummariesExportComponent implements OnDestroy, OnInit {
     });
   }
 
+  // ngOnChanges() : void {
+  //   this.clearSelections();
+  // }
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['organization'] && !changes['organization'].firstChange) {
+      this.clearSelections();
+    }
+  }
+
   ngOnInit(): void {
     this.selectedExportView = new BehaviorSubject<ExportView>(undefined);
 
@@ -113,11 +122,20 @@ export class ProfileSummariesExportComponent implements OnDestroy, OnInit {
 
   }
 
+
+  private clearSelections(): void {
+    console.log(this.selectedPeopleSubject.value);
+    this.selectedPeopleSubject.next([]);
+  }
+
   public getSelectedExportView(): Observable<ExportView> {
     return this.selectedExportView.asObservable();
   }
 
   public onSelectAll(event: Event, organization: any): void {
+    const currentOrgIds = (organization.people || []).map(p => p.id);
+    console.log(currentOrgIds);
+    console.log(organization.name);
     const checked = (event.target as HTMLInputElement).checked;
     const people = organization.people || [];
     if (checked) {
@@ -147,6 +165,11 @@ export class ProfileSummariesExportComponent implements OnDestroy, OnInit {
     return contentDisposition?.match(/^.*filename=(.*)$/)[1]?.trim() || defaultFileName;
   }
 
+  public isPersonSelected(person: any): boolean {
+    const list = this.selectedPeopleSubject.value || [];
+    return list.some(p => p.id === person.id);
+  }
+
   public downloadSelectedPeople(organization: any, selected: any): void {
     this.route.queryParams.pipe(take(1)).subscribe((params) => {
       const orgId = params?.selectedOrganization ? params.selectedOrganization : organization.id;
@@ -158,6 +181,8 @@ export class ProfileSummariesExportComponent implements OnDestroy, OnInit {
       }
 
       if (!selectedIds.length || selectedIds.length === (organization.people?.length ?? 0)) {
+        console.log("IF org name: ", organization.name );
+        console.log("IF selectedIds: ", selectedIds );
         const link = params?.export.toLowerCase().replace(/ /g, '_');
         this.restService.get<Blob>(
           organization._links[link].href,
@@ -168,6 +193,8 @@ export class ProfileSummariesExportComponent implements OnDestroy, OnInit {
             this.download(response, filename);
           },);
       } else {
+        console.log("else org name: ", organization.name );
+        console.log("IF selectedIds: ", selectedIds );
         const exportName = (selected?.name ? selected.name : params?.export ? params.export : '')
                           .trim().replace(/\s+/g, ' ');
         const updatedHref = `${this.appConfig.serviceUrl}/individual/${orgId}/export?type=zip&name=${encodeURIComponent(exportName)}`;

--- a/src/app/+data-and-analytics/profile-summaries-export/profile-summaries-export.component.ts
+++ b/src/app/+data-and-analytics/profile-summaries-export/profile-summaries-export.component.ts
@@ -73,9 +73,6 @@ export class ProfileSummariesExportComponent implements OnDestroy, OnChanges, On
     });
   }
 
-  // ngOnChanges() : void {
-  //   this.clearSelections();
-  // }
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['organization'] && !changes['organization'].firstChange) {
       this.clearSelections();
@@ -122,9 +119,7 @@ export class ProfileSummariesExportComponent implements OnDestroy, OnChanges, On
 
   }
 
-
   private clearSelections(): void {
-    console.log(this.selectedPeopleSubject.value);
     this.selectedPeopleSubject.next([]);
   }
 
@@ -181,8 +176,6 @@ export class ProfileSummariesExportComponent implements OnDestroy, OnChanges, On
       }
 
       if (!selectedIds.length || selectedIds.length === (organization.people?.length ?? 0)) {
-        console.log("IF org name: ", organization.name );
-        console.log("IF selectedIds: ", selectedIds );
         const link = params?.export.toLowerCase().replace(/ /g, '_');
         this.restService.get<Blob>(
           organization._links[link].href,
@@ -193,8 +186,6 @@ export class ProfileSummariesExportComponent implements OnDestroy, OnChanges, On
             this.download(response, filename);
           },);
       } else {
-        console.log("else org name: ", organization.name );
-        console.log("IF selectedIds: ", selectedIds );
         const exportName = (selected?.name ? selected.name : params?.export ? params.export : '')
                           .trim().replace(/\s+/g, ' ');
         const updatedHref = `${this.appConfig.serviceUrl}/individual/${orgId}/export?type=zip&name=${encodeURIComponent(exportName)}`;


### PR DESCRIPTION
# Description

 - Added isPersonSelected() to check selection by ID

 - Updated onSelectAll() to use slected organization’s people IDs

 - Added ngOnChanges() to clear selections on org change

 - Added clearSelections() to reset the selectedPeopleSubject of type: BehaviorSubject

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing Procedures

Verified on labs environment:
Steps:
1. From deafult selected organization  -Texas A&M University 
2.  Select Coronado, Sergio; Ponsford, Bennett and Ho, Jeanette
3. Click Download - Verify download has 3 files
5. In the search bar, type “Nuclear Engineering” (without refreshing page)
6. Select Adams, Marvin, Mcdeavitt, Sean, and Kirkland, Karen
7. Click Download -  Ensure download has 3 files and not 6 files.

Please see attachment:
Step 1:
<img width="692" height="772" alt="Screenshot 2025-11-20 at 4 41 00 PM" src="https://github.com/user-attachments/assets/50fe951f-49de-4433-af3a-d0226bd8ca74" />
Step 5:
<img width="701" height="668" alt="Screenshot 2025-11-20 at 4 41 55 PM" src="https://github.com/user-attachments/assets/4c3659e1-f56e-4e21-8229-54a768539455" />

in the downloads folder: 
<img width="849" height="397" alt="Screenshot 2025-11-20 at 4 43 42 PM" src="https://github.com/user-attachments/assets/b1a4ec2c-f581-4bf7-a881-d0934ec6bd46" />


