### PR TITLE
Sort names by last name for Download profile summary.

### DIFF
--- a/src/app/+data-and-analytics/data-and-analytics.module.ts
+++ b/src/app/+data-and-analytics/data-and-analytics.module.ts
@@ -14,6 +14,7 @@ import { FrequencyGraphComponent } from './frequency-graph/frequency-graph.compo
 import { ScatterplotComponent } from './frequency-graph/scatterplot/scatterplot.component';
 import { ProfileSummariesExportComponent } from './profile-summaries-export/profile-summaries-export.component';
 import { QuantityDistributionComponent } from './quantity-distribution/quantity-distribution.component';
+import { SortOrgPeople } from '../shared/utilities/sort-org-people.pipe';
 
 @NgModule({
   declarations: [
@@ -24,6 +25,7 @@ import { QuantityDistributionComponent } from './quantity-distribution/quantity-
     ProfileSummariesExportComponent,
     QuantityDistributionComponent,
     ScatterplotComponent,
+    SortOrgPeople
   ],
   imports: [
     CommonModule,

--- a/src/app/+data-and-analytics/profile-summaries-export/profile-summaries-export.component.html
+++ b/src/app/+data-and-analytics/profile-summaries-export/profile-summaries-export.component.html
@@ -23,7 +23,7 @@
         </button>
       </div>
       <ul>
-        <li *ngFor="let person of organization.people">
+        <li *ngFor="let person of organization.people | sortOrgPeople">
           <div class="form-check">
             <input
               id="selected-profile"

--- a/src/app/shared/utilities/sort-org-people.pipe.ts
+++ b/src/app/shared/utilities/sort-org-people.pipe.ts
@@ -32,7 +32,7 @@ export class SortOrgPeople implements PipeTransform {
       const aFirst = this.extractFirstName(a.label);
       const bFirst = this.extractFirstName(b.label);
 
-      return aFirst.localeCompare(bFirst);;
+      return aFirst.localeCompare(bFirst);
     });
 
     return copy;

--- a/src/app/shared/utilities/sort-org-people.pipe.ts
+++ b/src/app/shared/utilities/sort-org-people.pipe.ts
@@ -1,0 +1,53 @@
+import { Pipe, PipeTransform} from '@angular/core';
+
+@Pipe({
+  name: 'sortOrgPeople',
+  pure: true
+})
+export class SortOrgPeople implements PipeTransform {
+
+  private extractLastName(label: string): string {
+    if (!label) return '';
+    return label.split(',')[0].trim().toLowerCase();
+  }
+
+  private extractFirstName(label: string): string {
+    if (!label) return '';
+    const afterComma = label.split(',')[1] || '';
+    return afterComma.trim().split(/\s+/)[0].toLowerCase();
+  }
+
+  private extractMiddleName(label: string): string {
+    if (!label) return '';
+    const afterComma = label.split(',')[1] || '';
+    const parts = afterComma.trim().split(/\s+/);
+    return parts.length > 1 ? parts[1].toLowerCase() : '';
+  }
+
+  transform(people: any[], direction: 'ASC' | 'DESC' = 'ASC'): any[] {
+    if (!Array.isArray(people) || people.length === 0) return people || [];
+
+    const copy = [...people];
+
+    copy.sort((a, b) => {
+      const aLast = this.extractLastName(a.label);
+      const bLast = this.extractLastName(b.label);
+
+      let cmp = aLast.localeCompare(bLast);
+      if (cmp !== 0) return cmp;
+
+      const aFirst = this.extractFirstName(a.label);
+      const bFirst = this.extractFirstName(b.label);
+
+      cmp = aFirst.localeCompare(bFirst);
+      if (cmp !== 0) return cmp;
+
+      const aMiddle = this.extractMiddleName(a.label);
+      const bMiddle = this.extractMiddleName(b.label);
+
+      return aMiddle.localeCompare(bMiddle);
+    });
+
+    return copy;
+  }
+}

--- a/src/app/shared/utilities/sort-org-people.pipe.ts
+++ b/src/app/shared/utilities/sort-org-people.pipe.ts
@@ -13,21 +13,14 @@ export class SortOrgPeople implements PipeTransform {
 
   private extractFirstName(label: string): string {
     if (!label) return '';
-    const afterComma = label.split(',')[1] || '';
-    return afterComma.trim().split(/\s+/)[0].toLowerCase();
-  }
-
-  private extractMiddleName(label: string): string {
-    if (!label) return '';
-    const afterComma = label.split(',')[1] || '';
-    const parts = afterComma.trim().split(/\s+/);
-    return parts.length > 1 ? parts[1].toLowerCase() : '';
+    const afterComma = label.split(',')[1];
+    return afterComma ? afterComma.trim().split(/\s+/)[0].toLowerCase() : '';
   }
 
   transform(people: any[], direction: 'ASC' | 'DESC' = 'ASC'): any[] {
     if (!Array.isArray(people) || people.length === 0) return people || [];
 
-    const copy = [...people];
+    const copy = [ ...people ];
 
     copy.sort((a, b) => {
       const aLast = this.extractLastName(a.label);
@@ -39,13 +32,7 @@ export class SortOrgPeople implements PipeTransform {
       const aFirst = this.extractFirstName(a.label);
       const bFirst = this.extractFirstName(b.label);
 
-      cmp = aFirst.localeCompare(bFirst);
-      if (cmp !== 0) return cmp;
-
-      const aMiddle = this.extractMiddleName(a.label);
-      const bMiddle = this.extractMiddleName(b.label);
-
-      return aMiddle.localeCompare(bMiddle);
+      return aFirst.localeCompare(bFirst);;
     });
 
     return copy;


### PR DESCRIPTION
Resolves #513 
# Description

- Resolves 513 - Sort names by last name for Download profile summaries section.
- Added sortOrgPeople pipe.
- Initially the last names are compared followed by first and middle names.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Procedures

Verified this on local set up.



