### PR TITLE
Fix Profile Summaries Export search dropdown when org name is null.

### DIFF
--- a/src/app/+data-and-analytics/data-and-analytics.component.ts
+++ b/src/app/+data-and-analytics/data-and-analytics.component.ts
@@ -225,12 +225,15 @@ export class DataAndAnalyticsComponent implements OnInit {
     return text.pipe(
       distinctUntilChanged(),
       map((term) => this.organizationsSubject.value
-        .filter(org => org.name.toLowerCase().includes(term.toLowerCase()))
+        .filter(org => (org.name ?? '').toLowerCase().includes((term ?? '').toLowerCase()))
       )
     );
   }
 
-  public formatter = (organization: Individual) => organization.name;
+  public formatter = (organization: Individual | null) => {
+    if (!organization) { return ''; }
+    return organization?.name || 'No name availlable';
+  };
 
   public onSelectOrganization(event: any, params: Params): void {
     let id = event;
@@ -297,7 +300,12 @@ export class DataAndAnalyticsComponent implements OnInit {
     }
 
     return this.individualRepo.search({ filters, page })
-      .pipe(map(collection => (collection._embedded.individual as Individual[]).sort((a, b) => a.name.localeCompare(b.name))));
+      .pipe(
+        map(
+          collection => (collection._embedded.individual as Individual[])
+            .sort((a, b) => (a?.name ?? '').localeCompare(b?.name ?? ''))
+          )
+        );
   }
 
 }


### PR DESCRIPTION
## Description

This is about the recent problem with the dropdown not showing up under `Data & Analytics -> Download Profile Summaries by Department` when searching/filtering by Organization.

The original code didn't account for null values when the organization name is empty. It seems that the problem only exists in the Data & Analytics module, because under Organizations, if an Organization has no name it shows as "No name available".

<img width="1245" height="352" alt="image" src="https://github.com/user-attachments/assets/f7635797-45bd-458d-b8ff-562d89170c27" />

My fix adds null checks and returns the same "No name available" in the search dropdown and it doesn't seem to break other things, but more QA is always helpful.

```
.filter(org => (org.name ?? '').toLowerCase().includes((term ?? '').toLowerCase()))
....
public formatter = (organization: Individual | null) => {
    if (!organization) { return ''; }
    return organization?.name || 'No name availlable';
};
....
.sort((a, b) => (a?.name ?? '').localeCompare(b?.name ?? ''))
```
<img width="1235" height="461" alt="image" src="https://github.com/user-attachments/assets/af2d92b8-0997-437e-b14b-705952237e02" />


## Testing Procedures

In order to test this you need some "bad data" in the triple that has null organization names. The solr core on DEV's `scholars-solr` currently has the bad data in there from Dec 12's index when it was broken. But it's now good on Prod because after a few days' updates/rebuilds and indexing there is no longer a null org name.