### PR TITLE
Test section expand collapse

### DIFF
--- a/src/app/+display/display.component.html
+++ b/src/app/+display/display.component.html
@@ -16,7 +16,7 @@
       <div [ngClass]="{ 'col-lg-9': showAside(displayView, individual), 'col-lg-12': !showAside(displayView, individual) }">
         <div class="row mt-2">
           <div *ngIf="showLeftScan(displayView)" class="col-md-{{ getLeftScanColSize(displayView) }}" [innerHtml]="displayView.leftScanTemplateFunction(individual) | safeHtml"></div>
-          <div *ngIf="showMainContent(displayView)" class="col-md-{{ getMainContentColSize(displayView) }}" [innerHtml]="displayView.mainContentTemplateFunction(individual) | safeHtml"></div>
+          <div #mainContent *ngIf="showMainContent(displayView)" class="col-md-{{ getMainContentColSize(displayView) }}" [innerHtml]="displayView.mainContentTemplateFunction(individual) | safeHtml"></div>
           <div *ngIf="showRightScan(displayView)" class="col-md-{{ getRightScanColSize(displayView) }}" [innerHtml]="displayView.rightScanTemplateFunction(individual) | safeHtml"></div>
         </div>
         <div class="row mt-4 mb-4">

--- a/src/app/+display/display.component.ts
+++ b/src/app/+display/display.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Inject, OnDestroy, OnInit, PLATFORM_ID } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostListener, Inject, OnDestroy, OnInit, PLATFORM_ID } from '@angular/core';
 import { MetaDefinition } from '@angular/platform-browser';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { Store, select } from '@ngrx/store';
@@ -332,6 +332,30 @@ export class DisplayComponent implements OnDestroy, OnInit {
       }
     }
     return metaTags;
+  }
+
+  @HostListener('click', ['$event'])
+  public onMainContentClick(event: MouseEvent): void {
+    const target = event.target as HTMLElement;
+
+    if (!target) return;
+
+    const toggleBtn = target.closest<HTMLButtonElement>('.toggle-btn');
+
+    if (!toggleBtn) return;
+
+    const container = toggleBtn.closest('.research-areas') as HTMLElement;
+
+    if (!container) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const nextState = !(container.getAttribute('data-expanded') === 'true');
+
+    container.setAttribute('data-expanded', String(nextState));
+    toggleBtn.textContent = nextState ? 'Show less' : 'Show more';
+    toggleBtn.setAttribute('aria-expanded', String(nextState));
   }
 
 }


### PR DESCRIPTION
# Description

This feature enables the expand collapse feature in the research areas in an Organization.
- added #mainContent template reference to main-content div section
- Added a listener block for registering click events to toggle research areas  - expand or collapse
- updated aria-expanded and button label  - Show more and Show less on toggle.

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# Testing Procedures

Verified this feature works on local.
Click link: To see more click on Show more link.
<img width="1216" height="739" alt="Screenshot 2026-01-22 at 5 46 26 PM" src="https://github.com/user-attachments/assets/33b4cc13-2343-46ce-b714-b63c0661bc55" />
Click link: To see the collapsed version, click Show less link.
<img width="1196" height="990" alt="Screenshot 2026-01-22 at 5 46 46 PM" src="https://github.com/user-attachments/assets/a7792f16-f737-411f-9473-03425600f8b6" />

